### PR TITLE
Fix get_host_variables for system tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -48,7 +48,7 @@ class HostManager:
         variable_manager = VariableManager(loader=data_loader, inventory=self.inventory_manager)
 
         for host in self.inventory_manager.get_hosts():
-            self.hosts_variables[host] = variable_manager.get_vars(host=self.inventory_manager.get_host(str(host)))
+            self.hosts_variables[str(host)] = variable_manager.get_vars(host=self.inventory_manager.get_host(str(host)))
 
     def get_inventory(self) -> dict:
         """Get the loaded Ansible inventory.
@@ -114,10 +114,7 @@ class HostManager:
         Example:
             variables = get_host_variables('my_host')
         """
-
-        inventory_manager_host = self.inventory_manager.get_host(host)
-
-        return self.hosts_variables[inventory_manager_host]
+        return self.hosts_variables[host]
 
     def get_host(self, host: str):
         """Get the Ansible object for communicating with the specified host.


### PR DESCRIPTION
## Description

This PR addresses the get_host_variables method to prevent potential system test failures. The resolution of the `KeyError` issue can be found in the following link: [PR #4954](https://github.com/wazuh/wazuh-qa/pull/4954).


## Testing performed


[OneManagerAgent.zip](https://github.com/wazuh/wazuh-qa/files/14261645/OneManagerAgent.zip)

> [!NOTE]
> This fix has only been tested in a `one_manager_agent` environment for system tests. However, it should address failures across all environments with this improvement.

Furthermore, it has been verified that end-to-end (E2E) tests retain access to the inventory data following this adjustment.
```
In [8]: hm.get_host_variables('agent1')['os_name']
Out[8]: 'linux'

In [9]: hm.get_host_variables('agent2')['os_name']
Out[9]: 'windows'

In [10]: hm.get_host_variables('agent3')['os_name']
Out[10]: 'linux'

In [11]: hm.get_host_variables('agent4')['os_name']
Out[11]: 'linux'
```