### PR TITLE
Added support for labels for AWS EC2 creation

### DIFF
--- a/deployability/launchers/allocation.py
+++ b/deployability/launchers/allocation.py
@@ -19,7 +19,9 @@ def parse_arguments():
     parser.add_argument("--track-output", required=False, default='/tmp/wazuh-qa/track.yml')
     parser.add_argument("--inventory-output", required=False, default='/tmp/wazuh-qa/inventory.yml')
     parser.add_argument("--working-dir", required=False, default='/tmp/wazuh-qa')
-    parser.add_argument("--label", action='append', required=False, default=None)
+    parser.add_argument("--label-issue", required=False, default=None)
+    parser.add_argument("--label-team", required=False, default=None)
+    parser.add_argument("--label-termination-date", required=False, default=None)
     return parser.parse_args()
 
 

--- a/deployability/launchers/allocation.py
+++ b/deployability/launchers/allocation.py
@@ -19,6 +19,7 @@ def parse_arguments():
     parser.add_argument("--track-output", required=False, default='/tmp/wazuh-qa/track.yml')
     parser.add_argument("--inventory-output", required=False, default='/tmp/wazuh-qa/inventory.yml')
     parser.add_argument("--working-dir", required=False, default='/tmp/wazuh-qa')
+    parser.add_argument("--label", action='append', required=False, default=None)
     return parser.parse_args()
 
 

--- a/deployability/modules/allocation/aws/models.py
+++ b/deployability/modules/allocation/aws/models.py
@@ -8,3 +8,8 @@ class AWSConfig(ProviderConfig):
     key_name: str
     type: str
     security_groups: list[str]
+    termination_date: str
+    issue: str
+    team: str
+    name: str
+

--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -1,6 +1,8 @@
 import boto3
 import fnmatch
 import os
+import re
+import sys
 from pathlib import Path
 
 from modules.allocation.generic import Provider
@@ -39,18 +41,45 @@ class AWSProvider(Provider):
         temp_id = cls._generate_instance_id(cls.provider_name)
         temp_dir = base_dir / temp_id
         credentials = AWSCredentials()
+        teams = ['qa', 'core', 'framework', 'cicd', 'frontend', 'operations', 'cloud', 'threat-intel', 'marketing', 'documentation']
         if not config:
             logger.debug(f"No config provided. Generating from payload")
+            # Labels
+            issue = None
+            label_team = None
+            termination_date = None
+            date_regex = r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}"
+            for label in params.label:
+                url_regex = "(https:\/\/www\.|http:\/\/www\.|https:\/\/|http:\/\/)?[a-zA-Z0-9]{2,}(\.[a-zA-Z0-9]{2,})(\.[a-zA-Z0-9]{2,})?"
+                if re.match(url_regex, label):
+                    issue = label
+                for team in teams:
+                    if label == team:
+                        label_team = label
+                if re.match(date_regex, label):
+                    termination_date = label
+            if not termination_date:
+                logger.error(f"The termination_date label was not provided or is of incorrect format, example: 2024-02-25 12:00:00.")
+                sys.exit(1)
+            if not label_team:
+                logger.error(f"The team label was not provided.")
+                sys.exit(1)
+            if not issue:
+                logger.error(f"The issue label was not provided.")
+                sys.exit(1)
+            issue_name= re.search(r'github\.com\/wazuh\/([^\/]+)\/issues', issue)
+            name = str(issue_name.group(1)) + "-" + str(re.search(r'(\d+)$', issue).group(1)) + "-" + str(params.composite_name.split("-")[1]) + "-" + str(params.composite_name.split("-")[2])
+
             # Keys.
             if not ssh_key:
                 logger.debug(f"Generating new key pair")
-                credentials.generate(temp_dir, temp_id.split('-')[-1] + '_key')
+                credentials.generate(temp_dir, str('-'.join(name.split("-")[:-2])))
             else:
                 logger.debug(f"Using provided key pair")
                 key_id = credentials.ssh_key_interpreter(ssh_key)
                 credentials.load(key_id)
             # Parse the config if it is not provided.
-            config = cls.__parse_config(params, credentials)
+            config = cls.__parse_config(params, credentials, issue, label_team, termination_date, name)
         else:
             logger.debug(f"Using provided config")
             # Load the existing credentials.
@@ -122,13 +151,23 @@ class AWSProvider(Provider):
                                             InstanceType=config.type,
                                             KeyName=config.key_name,
                                             SecurityGroupIds=config.security_groups,
-                                            MinCount=1, MaxCount=1)[0]
+                                            MinCount=1, MaxCount=1,
+                                            TagSpecifications=[{
+                                                'ResourceType': 'instance',
+                                                'Tags': [
+                                                    {'Key': 'Name', 'Value': config.name},
+                                                    {'Key': 'termination_date', 'Value': config.termination_date},
+                                                    {'Key': 'issue', 'Value': config.issue},
+                                                    {'Key': 'team', 'Value': config.team}
+                                                ]
+                                            }]
+                                            )[0]
         # Wait until the instance is running.
         instance.wait_until_running()
         return instance.instance_id
 
     @classmethod
-    def __parse_config(cls, params: CreationPayload, credentials: AWSCredentials) -> AWSConfig:
+    def __parse_config(cls, params: CreationPayload, credentials: AWSCredentials, issue: str, team: str, termination_date: str, name: str) -> AWSConfig:
         """
         Parse configuration parameters for creating an AWS EC2 instance.
 
@@ -157,5 +196,9 @@ class AWSProvider(Provider):
         config['user'] = os_specs['user']
         config['key_name'] = credentials.name
         config['security_groups'] = mics_specs['security-group']
+        config['termination_date'] = termination_date
+        config['issue'] = issue
+        config['team'] = team
+        config['name'] = name
 
         return AWSConfig(**config)

--- a/deployability/modules/allocation/generic/models.py
+++ b/deployability/modules/allocation/generic/models.py
@@ -43,7 +43,9 @@ class InputPayload(BaseModel):
     inventory_output: Path | None = working_dir / 'inventory.yml'
     ssh_key: str | None = None
     custom_provider_config: Path | None = None
-    label: list[str] | None = None
+    label_issue: str | None = None
+    label_team: str | None = None
+    label_termination_date: str | None = None
 
 class CreationPayload(InputPayload):
     provider: str
@@ -54,7 +56,9 @@ class CreationPayload(InputPayload):
     working_dir: Path
     ssh_key: str | None = None
     custom_provider_config: Path | None = None
-    label: list[str] | None = None
+    label_issue: str | None = None
+    label_team: str | None = None
+    label_termination_date: str | None = None
 
     @model_validator(mode='before')
     def validate_dependency(cls, values) -> dict:

--- a/deployability/modules/allocation/generic/models.py
+++ b/deployability/modules/allocation/generic/models.py
@@ -43,7 +43,7 @@ class InputPayload(BaseModel):
     inventory_output: Path | None = working_dir / 'inventory.yml'
     ssh_key: str | None = None
     custom_provider_config: Path | None = None
-
+    label: list[str] | None = None
 
 class CreationPayload(InputPayload):
     provider: str
@@ -54,6 +54,7 @@ class CreationPayload(InputPayload):
     working_dir: Path
     ssh_key: str | None = None
     custom_provider_config: Path | None = None
+    label: list[str] | None = None
 
     @model_validator(mode='before')
     def validate_dependency(cls, values) -> dict:


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-qa/issues/4866

The methods are updated to support the definition of tags for creating EC2 instances in AWS.

These are defined as mandatory since the script will fail if any of them are not defined. This is done this way because AWS accounts (for the moment wazuh-dev, but in the future all of them) have the definition of these 3 tags mandatory.

### Tests

- AWS:
  - https://github.com/wazuh/wazuh-qa/issues/4866#issuecomment-1947035728
  - https://github.com/wazuh/wazuh-qa/issues/4866#issuecomment-1947159264
  - https://github.com/wazuh/wazuh-qa/issues/4866#issuecomment-1947230243
- Vagrant:
  - https://github.com/wazuh/wazuh-qa/issues/4866#issuecomment-1946341960
  - https://github.com/wazuh/wazuh-qa/issues/4866#issuecomment-1947200487