### PR TITLE
Reduced test_shutdown_message runtime

### DIFF
--- a/tests/system/__init__.py
+++ b/tests/system/__init__.py
@@ -34,8 +34,6 @@ def get_id_from_agent(agent, host_manager):
 def restart_cluster(hosts_list, host_manager):
     # Restart the cluster's hosts
     for host in hosts_list:
-        if "agent" in host:
-            host_manager.get_host(host).ansible('command', f'service wazuh-agent restart', check=False)
         host_manager.control_service(host=host, service='wazuh', state="restarted")
 
 

--- a/tests/system/test_cluster/test_agent_groups/test_groups_sync_default.py
+++ b/tests/system/test_cluster/test_agent_groups/test_groups_sync_default.py
@@ -67,8 +67,8 @@ sync_delay = 40
 
 
 # Tests
-@pytest.mark.parametrize("agent_host", test_infra_managers[0:2])
-def test_agent_groups_sync_default(agent_host, clean_environment):
+@pytest.mark.parametrize("target_host", test_infra_managers[0:2])
+def test_agent_groups_sync_default(target_host, clean_environment):
     '''
     description: Check that after a long time when the manager has been unable to synchronize de databases, because
     new agents are being continually added, database synchronization is forced and the expected information is in
@@ -77,7 +77,7 @@ def test_agent_groups_sync_default(agent_host, clean_environment):
     in all the cluster nodes.
     wazuh_min_version: 4.4.0
     parameters:
-        - agent_host:
+        - target_host:
             type: List
             brief: Name of the host where the agent will register in each case.
         - clean_enviroment:
@@ -93,7 +93,7 @@ def test_agent_groups_sync_default(agent_host, clean_environment):
     # Register agents in manager
     agent_data = []
     for index, agent in enumerate(test_infra_agents):
-        data = register_agent(agent, agent_host, host_manager)
+        data = register_agent(agent, target_host, host_manager)
         agent_data.append(data)
 
     # get the time before all the process is started

--- a/tests/system/test_shutdown_message/test_shutdown_message.py
+++ b/tests/system/test_shutdown_message/test_shutdown_message.py
@@ -25,7 +25,7 @@ import os
 import pytest
 import re
 import time
-from wazuh_testing import T_1, T_3
+from wazuh_testing import T_1, T_5
 from wazuh_testing.tools import WAZUH_PATH
 from wazuh_testing.tools.system import HostManager
 from system import restart_cluster
@@ -49,11 +49,11 @@ pytestmark = [pytest.mark.cluster, pytest.mark.big_cluster_40_agents_env]
 
 @pytest.fixture()
 def restart_all_agents():
-    restart_cluster(testinfra_hosts + agents, host_manager)
+    restart_cluster(agents, host_manager, parallel=True)
     time.sleep(T_1)
 
     yield
-    restart_cluster(testinfra_hosts + agents, host_manager)
+    restart_cluster(testinfra_hosts + agents, host_manager, parallel=True)
 
 
 @pytest.fixture()
@@ -81,7 +81,7 @@ def test_shut_down_message_gracefully_stopped_agent(restart_all_agents, stop_gra
         expected_output:
             - Gracefully closed, it is expected to find agents 'Disconected' in agent-manager
     '''
-    time.sleep(T_3)
+    time.sleep(T_5)
 
     matches = re.findall(r"Disconnected", host_manager.run_command(testinfra_hosts[0],
                                                                    f'{WAZUH_PATH}/bin/agent_control -l'))


### PR DESCRIPTION
|Related issue|
|:--:|
| #4942 |

## Description

The execution time of the `test_shutdown_message` test has been reduced from almost 20 minutes to 2 minutes. This has been achieved thanks to the parallelization of the agent restart (which was also a requirement of the test).



---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

|OS|Package used|
|--|--|
|System tests provisioning|v4.8.0-beta1|

 | Local   | Commit | Notes                |
|---------|-----|--------|
| [🟢 ](https://github.com/wazuh/wazuh-qa/files/14344827/big_cluster_40_agents.zip) |   8996e45       | Nothing to highlight |