### PR TITLE
QA - Fix Vulnerability Detection mismatch in scans by addingFORMAT field to GlobalDB Query

### DIFF
--- a/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
+++ b/tests/integration/test_wazuh_db/data/agent/agent_messages.yaml
@@ -88,5 +88,5 @@
       stage: agent sync_info set synced
     -
       input: agent 003 package get
-      output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}','due {"name":"test_rpm_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","item_id":"1"}','ok {"status":"SUCCESS"}']
+      output: ['due {"name":"test_deb_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","format":"deb","item_id":"1"}', 'due {"name":"test_rpm_pkg","version":"1.0.0","architecture":"amd64","vendor":"Wazuh wazuh@wazuh.com","format":"rpm","item_id":"1"}', 'ok {"status":"SUCCESS"}']
       stage: agent sys_programs getting not all packages


### PR DESCRIPTION
|Related issue|
|---|
|[#22241](https://github.com/wazuh/wazuh/issues/22241)|

## Objective
This PR addresses the critical issue of mismatched results between normal vulnerability scans and re-scans within the Vulnerability Detection module, by incorporating the `FORMAT` field into the query to the global database (GlobalDB), we aim to enhance the accuracy and consistency of vulnerability detection results, ensuring that scans accurately reflect the current state of system vulnerabilities.

## Description

Modify the current mock to add the missing format field.