### PR TITLE
Fix agent groups tests for enrollment_cluster environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix agent groups tests for enrollment_cluster environment ([#5086](https://github.com/wazuh/wazuh-qa/pull/5086)) \- (Framework + Tests)
 - Fix initial scans tests ([5032](https://github.com/wazuh/wazuh-qa/pull/5032)) \- (Framework + Tests)
 - Handle VDT data missing in wazuh-db API ([5014](https://github.com/wazuh/wazuh-qa/pull/5014)) \- (Framework + Tests)
 - Fixed x-axis labels in data-visualizer script ([#4987 ](https://github.com/wazuh/wazuh-qa/pull/4987)) \- (Framework)

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -439,7 +439,7 @@ class HostManager:
             internal_options_data = []
             backup_local_internal_options = self.get_file_content(target_host, WAZUH_LOCAL_INTERNAL_OPTIONS)
             for internal_options in local_internal_options[target_host]:
-                internal_options_data.append(f"{internal_options['name']}={internal_options['value']}\n")
+                internal_options_data.append(f"\n{internal_options['name']}={internal_options['value']}\n")
             replace = backup_local_internal_options
             for internal_option in internal_options_data:
                 replace = replace + internal_option

--- a/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
+++ b/tests/system/test_cluster/test_agent_groups/test_agent_groups.py
@@ -35,7 +35,7 @@ tmp_path = os.path.join(local_path, 'tmp')
 # Variables
 test_group = 'test_group'
 while_time = 5
-time_to_sync = 21
+time_to_sync = 25
 time_to_agent_reconnect = 180
 queries = ['sql select * from "group" where name="test_group"']
 

--- a/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_agent_to_a_group.py
@@ -66,7 +66,7 @@ tmp_path = os.path.join(local_path, 'tmp')
 
 # Variables
 test_group = 'group_test'
-timeout = 10
+timeout = 25
 
 
 # Tests

--- a/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
@@ -150,7 +150,7 @@ def test_guess_single_group(target_node, status_guess_agent_group, clean_environ
     assert check_keys_file(test_infra_agents[0], host_manager), ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND
 
     try:
-        # Create new group and assign agent
+        # Assign agent to group
         assign_agent_to_new_group(test_infra_managers[0], group_id, agent_id, host_manager)
 
         # Remove agent from default to test single group guess (not multigroup)


### PR DESCRIPTION
|Related issue|
|:--:|
| #5041 |

## Description
- `test_assign_groups_guess.py`: Fix internal options
- `test_agent_groups.py`: Increase timeout
- `test_assign_agent_to_a_group.py`: Increase timeout

---

## Testing performed


|Package used|
|--|
|https://packages-dev.wazuh.com/pre-release/apt/pool/main/w/wazuh-manager/wazuh-manager_4.8.0-1_amd64.deb|
|https://packages-dev.wazuh.com/pre-release/apt/pool/main/w/wazuh-agent/wazuh-agent_4.8.0-1_amd64.deb|

| Validation  | Local   | Commit | Notes                |
|--------------------|-----------|---------|--------|
|   `test_assign_groups_guess.py`         | [🟢](https://github.com/wazuh/wazuh-qa/files/14527657/assign_groups_guess.zip) |      0553a1a        | Nothing to highlight |
|     `test_agent_groups.py`      | [🟢 ](https://github.com/wazuh/wazuh-qa/files/14526993/agent_groups.zip) |     09f5ba6240b30b01077db54447f2303e10b06d67         | Nothing to highlight |
|   `test_assign_agent_to_a_group.py`        | [🟢 ](https://github.com/wazuh/wazuh-qa/files/14526996/assign_agent_to_a_group.zip) |      09f5ba6240b30b01077db54447f2303e10b06d67        | Nothing to highlight |