### PR TITLE
Cast box and box_version to str

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -44,8 +44,8 @@ vagrant:
     box_version: 1.0.20240207
   # Centos
   linux-centos-7-amd64:
-    box: generic/centos7
-    box_version: 4.3.8
+    box: centos/7
+    box_version: 2004.01
   linux-centos-8-amd64:
     box: generic/centos8
     box_version: 4.3.8

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -145,8 +145,8 @@ class VagrantProvider(Provider):
         os_specs = cls._get_os_specs()[params.composite_name]
         # Parse the configuration.
         config['ip'] = cls.__get_available_ip()
-        config['box'] = os_specs['box']
-        config['box_version'] = os_specs['box_version']
+        config['box'] = str(os_specs['box'])
+        config['box_version'] = str(os_specs['box_version'])
         config['private_key'] = str(credentials.key_path)
         config['public_key'] = str(credentials.key_path.with_suffix('.pub'))
         config['cpu'] = size_specs['cpu']


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-qa/issues/5084

Str is cast to the box and box_version variables so that it adapts to the different types of vagrantbox versions that exist. A test is carried out with the centos/7 box since it previously failed due to the type of version it has:

Tests:

### Deploy Ubuntu

```console
  linux-ubuntu-16.04-amd64:
    box: generic/ubuntu1604
    box_version: 4.3.8
```

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --composite-name linux-ubuntu-16.04-amd64 --provider vagrant --size micro --ssh-key ~/.ssh/allocation_test [2024-03-08 09:51:36] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-08 09:51:36] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-08 09:51:36] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-08 09:51:39] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-03-08 09:51:39] [INFO] ALLOCATOR: Instance VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB created.
[2024-03-08 09:52:22] [INFO] ALLOCATOR: Instance VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB started.
[2024-03-08 09:52:25] [DEBUG] ALLOCATOR: Using provided credentials
[2024-03-08 09:52:25] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB/inventory.yml
[2024-03-08 09:52:25] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB/inventory.yml
ansible_host: 192.168.57.2
ansible_port: 22
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test vagrant@192.168.57.2
The authenticity of host '192.168.57.2 (192.168.57.2)' can't be established.
ED25519 key fingerprint is SHA256:1QLK6rJNSy5bZMm4EdgctjH+NxNUWBjNRxIQA7oRNJU.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.57.2' (ED25519) to the list of known hosts.
vagrant@ubuntu1604:~$ exit
logout
Connection to 192.168.57.2 closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --action delete --track-output /tmp/wazuh-qa/VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB/track.yml
[2024-03-08 09:53:32] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB/track.yml
[2024-03-08 09:53:32] [DEBUG] ALLOCATOR: The key /home/cbordon/.ssh/allocation_test will not be deleted. It is the user's responsibility to delete it.
[2024-03-08 09:53:32] [DEBUG] ALLOCATOR: Destroying instance VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB
[2024-03-08 09:53:37] [INFO] ALLOCATOR: Instance VAGRANT-7943322B-4CD2-4D97-8BB8-15FB5F750ADB deleted.
```
### Deploy Centos 7

```console
  linux-centos-7-amd64:
    box: centos/7
    box_version: 2004.01
```

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --composite-name linux-centos-7-amd64 --provider vagrant --size micro --ssh-key ~/.ssh/allocation_test 
[2024-03-08 09:57:56] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-08 09:57:56] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-08 09:57:56] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-08 09:57:59] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-03-08 09:57:59] [INFO] ALLOCATOR: Instance VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5 created.
[2024-03-08 09:59:38] [INFO] ALLOCATOR: Instance VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5 started.
[2024-03-08 09:59:41] [DEBUG] ALLOCATOR: Using provided credentials
[2024-03-08 09:59:41] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5/inventory.yml
[2024-03-08 09:59:41] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5/inventory.yml
ansible_host: 192.168.57.2
ansible_port: 22
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test vagrant@192.168.57.2
The authenticity of host '192.168.57.2 (192.168.57.2)' can't be established.
ED25519 key fingerprint is SHA256:5WfizJCqwV8PE+BXuemNWKdzgNoXXOyRL3phdYX7jYY.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.57.2' (ED25519) to the list of known hosts.
[vagrant@localhost ~]$ cat /etc/*release
CentOS Linux release 7.8.2003 (Core)
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

CentOS Linux release 7.8.2003 (Core)
CentOS Linux release 7.8.2003 (Core)
[vagrant@localhost ~]$ exit
logout
Connection to 192.168.57.2 closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --action delete --track-output /tmp/wazuh-qa/VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5/track.yml 
[2024-03-08 10:00:34] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5/track.yml
[2024-03-08 10:00:34] [DEBUG] ALLOCATOR: The key /home/cbordon/.ssh/allocation_test will not be deleted. It is the user's responsibility to delete it.
[2024-03-08 10:00:34] [DEBUG] ALLOCATOR: Destroying instance VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5
[2024-03-08 10:00:38] [INFO] ALLOCATOR: Instance VAGRANT-80425CBB-6681-4C13-AB2D-B7AC198520B5 deleted.
```