### PR TITLE
Update Indexer configuration in VD E2E tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Refactor initial scan Vulnerability E2E tests ([#5081](https://github.com/wazuh/wazuh-qa/pull/5081)) \- (Framework + Tests)
 - Update Packages in TestScanSyscollectorCases ([#4997](https://github.com/wazuh/wazuh-qa/pull/4997)) \- (Framework + Tests)
 - Reduced test_shutdown_message runtime ([#4986](https://github.com/wazuh/wazuh-qa/pull/4986)) \- (Tests)
 - Change e2e vd configuration keystore ([#4952](https://github.com/wazuh/wazuh-qa/pull/4952)) \- (Framework)
@@ -48,6 +49,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix test_shutdown_message system test ([#5087](https://github.com/wazuh/wazuh-qa/pull/5087)) \- (Tests)
+- Include timeout to test_authd system tests ([#5083](https://github.com/wazuh/wazuh-qa/pull/5083)) \- (Tests)
+- Fix Vulnerability Detection mismatch in scans ([#5053](https://github.com/wazuh/wazuh-qa/pull/5053)) \- (Tests)
 - Fix agent groups tests for enrollment_cluster environment ([#5086](https://github.com/wazuh/wazuh-qa/pull/5086)) \- (Framework + Tests)
 - Fix initial scans tests ([5032](https://github.com/wazuh/wazuh-qa/pull/5032)) \- (Framework + Tests)
 - Handle VDT data missing in wazuh-db API ([5014](https://github.com/wazuh/wazuh-qa/pull/5014)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
@@ -43,7 +43,7 @@ def wait_until_vd_is_updated(host_manager: HostManager) -> None:
         host_manager (HostManager): Host manager instance to handle the environment.
     """
 
-    monitoring_data = generate_monitoring_logs(host_manager, ["INFO: Action for 'vulnerability_feed_manager' finished"],
+    monitoring_data = generate_monitoring_logs(host_manager, ["INFO: Vulnerability scanner module started"],
                                                [VD_FEED_UPDATE_TIMEOUT], host_manager.get_group_hosts('manager'))
     monitoring_events_multihost(host_manager, monitoring_data)
 

--- a/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
@@ -21,10 +21,10 @@
                   elements:
                     - ca:
                         value: FILEBEAT_ROOT_CA
-          certificate:
-            value: FILEBEAT_CERTIFICATE
-          key:
-            value: FILEBEAT_KEY
+              - certificate:
+                  value: FILEBEAT_CERTIFICATE
+              - key:
+                  value: FILEBEAT_KEY
     - section: sca
       elements:
         - enabled:

--- a/tests/integration/test_wazuh_db/test_agent_database_version.py
+++ b/tests/integration/test_wazuh_db/test_agent_database_version.py
@@ -9,7 +9,7 @@ from wazuh_testing.tools.wazuh_manager import remove_all_agents
 pytestmark = [TIER0, LINUX, SERVER]
 
 # Variables
-expected_database_version = '13'
+expected_database_version = '14'
 
 
 # Fixtures
@@ -34,7 +34,7 @@ def test_agent_database_version(restart_wazuh_daemon, remove_agents):
             - Check that the manager database version is the expected one.
             - Check that the agent database version is the expected one.
 
-    wazuh_min_version: 4.4.0
+    wazuh_min_version: 4.8.0
 
     parameters:
         - restart_wazuh_daemon:
@@ -45,7 +45,7 @@ def test_agent_database_version(restart_wazuh_daemon, remove_agents):
         - Verify that database version is the expected one.
 
     expected_output:
-        - Database version: 13
+        - Database version: 14
 
     tags:
         - wazuh_db

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
     "version": "4.8.0",
-    "revision": "40805"
+    "revision": "40806"
 }


### PR DESCRIPTION
# Description

This PR updates the Indexer configuration in Vulnerability Detection E2E tests by incorporating key and certificate values into the SSL option. Additionally, it updates the regex for waiting until the end of the vulnerability content process. For further details, please refer to https://github.com/wazuh/wazuh-qa/issues/5126#issuecomment-2009312982

---

## Testing performed

This change only affects the setup fixture so it will only be tested on the `test_syscollector_first_scan`


| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | :no_entry_sign:  |  [R1.zip](https://github.com/wazuh/wazuh-qa/files/14692933/R1.zip) |         |         | Nothing to highlight |




