### PR TITLE
Fix number of files and their size for ` test_zip_size_limit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix number of files and their size for `test_zip_size_limit` ([#5133](https://github.com/wazuh/wazuh-qa/pull/5133)) \- (Tests)
 - Fix test_shutdown_message system test ([#5087](https://github.com/wazuh/wazuh-qa/pull/5087)) \- (Tests)
 - Include timeout to test_authd system tests ([#5083](https://github.com/wazuh/wazuh-qa/pull/5083)) \- (Tests)
 - Fix Vulnerability Detection mismatch in scans ([#5053](https://github.com/wazuh/wazuh-qa/pull/5053)) \- (Tests)

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -14,7 +14,7 @@ In the event that the tests are to be executed using AWS EC2 instances:
 |------------------------------|-------------------------------------------|
 |Basic_cluster                 |Ubuntu 22.04.2 LTS C5.XLarge 15GB SSD      |
 |Big_cluster_40_agents         |Ubuntu 22.04.2 LTS T3.Large 60GB SSD       |
-|Agentless_cluster             |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
+|Agentless_cluster             |Ubuntu 22.04.2 LTS C5.Large 30GB SSD       |
 |Four_manager_disconnected_node|Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
 |One_manager_agent             |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
 |Manager_agent                 |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -14,7 +14,7 @@ In the event that the tests are to be executed using AWS EC2 instances:
 |------------------------------|-------------------------------------------|
 |Basic_cluster                 |Ubuntu 22.04.2 LTS C5.XLarge 15GB SSD      |
 |Big_cluster_40_agents         |Ubuntu 22.04.2 LTS T3.Large 60GB SSD       |
-|Agentless_cluster             |Ubuntu 22.04.2 LTS C5.Large 30GB SSD       |
+|Agentless_cluster             |Ubuntu 22.04.2 LTS C5a.XLarge 30GB SSD       |
 |Four_manager_disconnected_node|Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
 |One_manager_agent             |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |
 |Manager_agent                 |Ubuntu 22.04.2 LTS T3.Large 30GB SSD       |

--- a/tests/system/test_cluster/test_integrity_sync/data/cluster_json.yaml
+++ b/tests/system/test_cluster/test_integrity_sync/data/cluster_json.yaml
@@ -1,5 +1,5 @@
 ---
 timeout_receiving_file: 1
-max_zip_size: 104857600    # 100 MB
-min_zip_size: 15728640    # 15 MB
+max_zip_size: 52428800    # 50 MB
+min_zip_size: 5242880    # 5 MB
 compress_level: 0

--- a/tests/system/test_cluster/test_integrity_sync/data/cluster_json.yaml
+++ b/tests/system/test_cluster/test_integrity_sync/data/cluster_json.yaml
@@ -1,5 +1,5 @@
 ---
 timeout_receiving_file: 1
-max_zip_size: 52428800    # 50 MB
+max_zip_size: 104857600    # 100 MB
 min_zip_size: 5242880    # 5 MB
 compress_level: 0

--- a/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
+++ b/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
@@ -57,25 +57,11 @@ files_not_to_sync = [os.path.join(WAZUH_PATH, 'etc', 'test_file'),
 tmp_size_test_path = os.path.join(WAZUH_PATH, 'tmp')
 dst_size_test_path = os.path.join(WAZUH_PATH, 'etc', 'rules')
 big_file_name = 'test_file_too_big'
-file_prefix = 'test_file_big_'
+file_prefix = 'test_file_'
 
 # merged.mg and agent.conf files that must be created after creating a group folder.
 merged_mg_file = os.path.join(directories_to_create[0], 'merged.mg')
 agent_conf_file = os.path.join(directories_to_create[0], 'agent.conf')
-
-
-# Functions
-
-def create_file(host, path, size):
-    """Create file of fixed size.
-
-    Args:
-        host (str): Host where the file should be created.
-        path (str): Path and name where to create the file.
-        size (int, str): Size of the file (if nothing specified, in bytes)
-    """
-    host_manager.run_command(host, f"fallocate -l {size} {path}")
-    host_manager.run_command(host, f"chown wazuh:wazuh {path}")
 
 
 # Fixtures
@@ -261,14 +247,16 @@ def test_zip_size_limit(clean_files, update_cluster_json):
         - The workers end up receiving all the files that do not exceed the maximum size.
     """
     too_big_size = configuration['max_zip_size'] + 1024
-    big_size = 1048576  # 1 MB
-    big_filenames = {file_prefix + str(i) for i in range(140)}
+    big_filenames = {file_prefix + str(i+1) for i in range(140)}
 
     # Create a tmp folder and all files inside in the master node.
     host_manager.run_command(test_hosts[0], f"mkdir {tmp_size_test_path}")
-    create_file(test_hosts[0], os.path.join(tmp_size_test_path, big_file_name), too_big_size)
-    for filename in big_filenames:
-        create_file(test_hosts[0], os.path.join(tmp_size_test_path, filename), big_size)
+    host_manager.run_command(test_hosts[0], f"fallocate -l {too_big_size} {tmp_size_test_path}/{big_file_name}")
+    host_manager.run_command(test_hosts[0], f"chown wazuh:wazuh {tmp_size_test_path}/{big_file_name}")
+    host_manager.run_shell(test_hosts[0],
+                           f"for i in `seq 1 140`; do fallocate -l 1M {tmp_size_test_path}/{file_prefix}$i; done")
+    host_manager.run_shell(test_hosts[0],
+                           f"for i in `seq 1 140`; do chown wazuh:wazuh {tmp_size_test_path}/{file_prefix}$i; done")
 
     # Move files from tmp folder to destination folder. This way, all files are synced at the same time.
     host_manager.run_shell(test_hosts[0], f"mv {os.path.join(tmp_size_test_path, 'test_*')} {dst_size_test_path}")

--- a/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
+++ b/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
@@ -262,7 +262,7 @@ def test_zip_size_limit(clean_files, update_cluster_json):
     """
     too_big_size = configuration['max_zip_size'] + 1024
     big_size = 1048576  # 1 MB
-    big_filenames = {file_prefix + str(i) for i in range(60)}
+    big_filenames = {file_prefix + str(i) for i in range(140)}
 
     # Create a tmp folder and all files inside in the master node.
     host_manager.run_command(test_hosts[0], f"mkdir {tmp_size_test_path}")

--- a/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
+++ b/tests/system/test_cluster/test_integrity_sync/test_integrity_sync.py
@@ -261,8 +261,8 @@ def test_zip_size_limit(clean_files, update_cluster_json):
         - The workers end up receiving all the files that do not exceed the maximum size.
     """
     too_big_size = configuration['max_zip_size'] + 1024
-    big_size = configuration['min_zip_size'] - 1024
-    big_filenames = {file_prefix + str(i) for i in range(10)}
+    big_size = 1048576  # 1 MB
+    big_filenames = {file_prefix + str(i) for i in range(60)}
 
     # Create a tmp folder and all files inside in the master node.
     host_manager.run_command(test_hosts[0], f"mkdir {tmp_size_test_path}")


### PR DESCRIPTION
|Related issue|
|:--:|
| #5100 |
## Description

Increased the number of files and decreased their size. In addition, we have changed the instance type from t3.large to c5.large.

| Validation | Local  | Commit | Notes                |
|--------------------|--------|-----|--------|
|     `agentless_cluster_env`      | [🟢 ](https://github.com/wazuh/wazuh-qa/files/14725243/agentless_cluster_1.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/14725244/agentless_cluster_2.zip)[🟢 ](https://github.com/wazuh/wazuh-qa/files/14725245/agentless_cluster_3.zip) |   1cea213           | Nothing to highlight |