### PR TITLE
Change Grafana Packages in Vulnerability Tests

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
@@ -35,13 +35,39 @@
       "CVE-2022-23498"
     ],
     "urls": {
-      "centos": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana-8.5.5-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana-8.5.5-1.aarch64.rpm"
-      },
       "ubuntu": {
         "amd64": "https://dl.grafana.com/oss/release/grafana_8.5.5_amd64.deb",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana_8.5.5_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-8.5.5-1": {
+    "package_name": "grafana",
+    "package_version": "8.5.5-1",
+    "CVE": [
+      "CVE-2023-2183",
+      "CVE-2023-1410",
+      "CVE-2023-0594",
+      "CVE-2023-0507",
+      "CVE-2022-39324",
+      "CVE-2022-39307",
+      "CVE-2022-39306",
+      "CVE-2022-39229",
+      "CVE-2022-39201",
+      "CVE-2022-36062",
+      "CVE-2022-35957",
+      "CVE-2022-31130",
+      "CVE-2022-31123",
+      "CVE-2022-31107",
+      "CVE-2022-31097",
+      "CVE-2022-23552",
+      "CVE-2022-23498"
+    ],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-8.5.5-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-8.5.5-1.aarch64.rpm"
       }
     },
     "uninstall_name": "grafana*"
@@ -69,13 +95,39 @@
       "CVE-2022-23498"
     ],
     "urls": {
-      "centos": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana-8.5.6-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana-8.5.6-1.aarch64.rpm"
-      },
       "ubuntu": {
         "amd64": "https://dl.grafana.com/oss/release/grafana_8.5.6_amd64.deb",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana_8.5.6_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-8.5.6-1": {
+    "package_name": "grafana",
+    "package_version": "8.5.6-1",
+    "CVE": [
+      "CVE-2023-2183",
+      "CVE-2023-1410",
+      "CVE-2023-0594",
+      "CVE-2023-0507",
+      "CVE-2022-39324",
+      "CVE-2022-39307",
+      "CVE-2022-39306",
+      "CVE-2022-39229",
+      "CVE-2022-39201",
+      "CVE-2022-36062",
+      "CVE-2022-35957",
+      "CVE-2022-31130",
+      "CVE-2022-31123",
+      "CVE-2022-31107",
+      "CVE-2022-31097",
+      "CVE-2022-23552",
+      "CVE-2022-23498"
+    ],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-8.5.6-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-8.5.6-1.aarch64.rpm"
       }
     },
     "uninstall_name": "grafana*"
@@ -99,13 +151,35 @@
       "CVE-2022-23498"
     ],
     "urls": {
-      "centos": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana-9.1.1-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.1.1-1.aarch64.rpm"
-      },
       "ubuntu": {
         "amd64": "https://dl.grafana.com/oss/release/grafana_9.1.1_amd64.deb",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.1.1_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-9.1.1-1": {
+    "package_name": "grafana",
+    "package_version": "9.1.1-1",
+    "CVE": [
+      "CVE-2023-2183",
+      "CVE-2023-1387",
+      "CVE-2022-39324",
+      "CVE-2022-39307",
+      "CVE-2022-39306",
+      "CVE-2022-39229",
+      "CVE-2022-39201",
+      "CVE-2022-36062",
+      "CVE-2022-35957",
+      "CVE-2022-31130",
+      "CVE-2022-31123",
+      "CVE-2022-23552",
+      "CVE-2022-23498"
+    ],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.1.1-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.1.1-1.aarch64.rpm"
       }
     },
     "uninstall_name": "grafana*"
@@ -114,36 +188,74 @@
     "package_name": "grafana",
     "package_version": "9.2.0",
     "CVE": [
-      "CVE-2021-25804",
-      "CVE-2021-25803",
-      "CVE-2021-25802",
-      "CVE-2021-25801",
-      "CVE-2020-26664"
+      "CVE-2023-3128",
+      "CVE-2023-22462",
+      "CVE-2023-2183",
+      "CVE-2023-1410",
+      "CVE-2023-1387",
+      "CVE-2023-0594",
+      "CVE-2023-0507",
+      "CVE-2022-39328",
+      "CVE-2022-39324",
+      "CVE-2022-39307",
+      "CVE-2022-39306",
+      "CVE-2022-23552",
+      "CVE-2022-23498"
+    ],
+    "urls": {
+      "ubuntu": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.2.0_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.2.0_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-9.2.0-1": {
+    "package_name": "grafana",
+    "package_version": "9.2.0-1",
+    "CVE": [
+      "CVE-2023-3128",
+      "CVE-2023-22462",
+      "CVE-2023-2183",
+      "CVE-2023-1410",
+      "CVE-2023-1387",
+      "CVE-2023-0594",
+      "CVE-2023-0507",
+      "CVE-2022-39328",
+      "CVE-2022-39324",
+      "CVE-2022-39307",
+      "CVE-2022-39306",
+      "CVE-2022-23552",
+      "CVE-2022-23498"
     ],
     "urls": {
       "centos": {
         "amd64": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.x86_64.rpm",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.aarch64.rpm"
-      },
-      "ubuntu": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana_9.2.0_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.2.0_arm64.deb"
-      },
-      "uninstall_name": "grafana*"
-    }
+      }
+    },
+    "uninstall_name": "grafana*"
   },
   "grafana-9.4.17": {
     "package_name": "grafana",
     "package_version": "9.4.17",
     "CVE": [],
     "urls": {
-      "centos": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.aarch64.rpm"
-      },
       "ubuntu": {
         "amd64": "https://dl.grafana.com/oss/release/grafana_9.4.17_amd64.deb",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.4.17_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-9.4.17-1": {
+    "package_name": "grafana",
+    "package_version": "9.4.17-1",
+    "CVE": [],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.aarch64.rpm"
       }
     },
     "uninstall_name": "grafana*"
@@ -153,13 +265,21 @@
     "package_version": "9.5.13",
     "CVE": [],
     "urls": {
-      "centos": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana-9.5.13-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.5.13-1.aarch64.rpm"
-      },
       "ubuntu": {
         "amd64": "https://dl.grafana.com/oss/release/grafana_9.5.13_amd64.deb",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.5.13_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-9.5.13-1": {
+    "package_name": "grafana",
+    "package_version": "9.5.13-1",
+    "CVE": [],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.5.13-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.5.13-1.aarch64.rpm"
       }
     },
     "uninstall_name": "grafana*"
@@ -172,13 +292,24 @@
       "CVE-2023-4399"
     ],
     "urls": {
-      "centos": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana-10.0.0-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana-10.0.0-1.aarch64.rpm"
-      },
       "ubuntu": {
         "amd64": "https://dl.grafana.com/oss/release/grafana_10.0.0_amd64.deb",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana_10.0.0_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-10.0.0-1": {
+    "package_name": "grafana",
+    "package_version": "10.0.0-1",
+    "CVE": [
+      "CVE-2023-4822",
+      "CVE-2023-4399"
+    ],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-10.0.0-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-10.0.0-1.aarch64.rpm"
       }
     },
     "uninstall_name": "grafana*"

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
@@ -36,12 +36,12 @@
     ],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-8.5.5-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-8.5.5-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-8.5.5-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-8.5.5-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_8.5.5_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_8.5.5_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_8.5.5_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_8.5.5_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"
@@ -70,12 +70,12 @@
     ],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-8.5.6-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-8.5.6-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-8.5.6-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-8.5.6-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_8.5.6_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_8.5.6_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_8.5.6_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_8.5.6_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"
@@ -100,12 +100,12 @@
     ],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.1.1-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.1.1-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.1.1-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.1.1-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.1.1_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.1.1_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.1.1_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.1.1_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"
@@ -122,12 +122,12 @@
     ],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.2.0-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.2.0-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.0_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.0_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.2.0_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.2.0_arm64.deb"
       },
       "uninstall_name": "grafana*"
     }
@@ -138,34 +138,34 @@
     "CVE": [],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.4.17-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.4.17-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.4.17_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.4.17_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.4.17_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.4.17_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"
   },
   "grafana-9.5.13": {
-    "package_name": "grafana-enterprise",
+    "package_name": "grafana",
     "package_version": "9.5.13",
     "CVE": [],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.5.13-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.5.13-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.5.13-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.5.13-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.5.13_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.5.13_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.5.13_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.5.13_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"
   },
   "grafana-10.0.0": {
-    "package_name": "grafana-enterprise",
+    "package_name": "grafana",
     "package_version": "10.0.0",
     "CVE": [
       "CVE-2023-4822",
@@ -173,12 +173,12 @@
     ],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-10.0.0-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-10.0.0-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-10.0.0-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-10.0.0-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_10.0.0_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_10.0.0_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_10.0.0_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_10.0.0_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -26,8 +26,8 @@
           state_index: true
         package:
           centos:
-            amd64: grafana-8.5.5
-            arm64v8: grafana-8.5.5
+            amd64: grafana-8.5.5-1
+            arm64v8: grafana-8.5.5-1
           ubuntu:
             amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
@@ -66,8 +66,8 @@
           state_index: true
         package:
           centos:
-            amd64: grafana-8.5.5
-            arm64v8: grafana-8.5.5
+            amd64: grafana-8.5.5-1
+            arm64v8: grafana-8.5.5-1
           ubuntu:
             amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
@@ -103,8 +103,8 @@
           state_index: true
         package:
           centos:
-            amd64: grafana-8.5.5
-            arm64v8: grafana-8.5.5
+            amd64: grafana-8.5.5-1
+            arm64v8: grafana-8.5.5-1
           ubuntu:
             amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
@@ -123,8 +123,8 @@
         package:
           from:
             centos:
-              amd64: grafana-8.5.5
-              arm64v8: grafana-8.5.5
+              amd64: grafana-8.5.5-1
+              arm64v8: grafana-8.5.5-1
             ubuntu:
               amd64: grafana-8.5.5
               arm64v8: grafana-8.5.5
@@ -135,8 +135,8 @@
               arm64v8: node-v17.0.1
           to:
             centos:
-              amd64: grafana-8.5.6
-              arm64v8: grafana-8.5.6
+              amd64: grafana-8.5.6-1
+              arm64v8: grafana-8.5.6-1
             ubuntu:
               amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
@@ -173,8 +173,8 @@
         package:
           from:
             centos:
-              amd64: grafana-8.5.6
-              arm64v8: grafana-8.5.6
+              amd64: grafana-8.5.6-1
+              arm64v8: grafana-8.5.6-1
             ubuntu:
               amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
@@ -185,8 +185,8 @@
               arm64v8: node-v17.1.0
           to:
             centos:
-              amd64: grafana-9.1.1
-              arm64v8: grafana-9.1.1
+              amd64: grafana-9.1.1-1
+              arm64v8: grafana-9.1.1-1
             ubuntu:
               amd64: grafana-9.1.1
               arm64v8: grafana-9.1.1
@@ -225,8 +225,8 @@
         package:
           from:
             centos:
-              amd64: grafana-8.5.6
-              arm64v8: grafana-8.5.6
+              amd64: grafana-8.5.6-1
+              arm64v8: grafana-8.5.6-1
             ubuntu:
               amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
@@ -237,8 +237,8 @@
               arm64v8: node-v18.11.0
           to:
             centos:
-              amd64: grafana-9.1.1
-              arm64v8: grafana-9.1.1
+              amd64: grafana-9.1.1-1
+              arm64v8: grafana-9.1.1-1
             ubuntu:
               amd64: grafana-9.1.1
               arm64v8: grafana-9.1.1
@@ -275,8 +275,8 @@
         package:
           from:
             centos:
-              amd64: grafana-9.1.1
-              arm64v8: grafana-9.1.1
+              amd64: grafana-9.1.1-1
+              arm64v8: grafana-9.1.1-1
             ubuntu:
               amd64: grafana-9.1.1
               arm64v8: grafana-9.1.1
@@ -287,8 +287,8 @@
               arm64v8: node-v18.12.0
           to:
             centos:
-              amd64: grafana-9.4.17
-              arm64v8: grafana-9.4.17
+              amd64: grafana-9.4.17-1
+              arm64v8: grafana-9.4.17-1
             ubuntu:
               arm64v8: grafana-9.4.17
               amd64: grafana-9.4.17
@@ -334,8 +334,8 @@
         package:
           from:
             centos:
-              amd64: grafana-9.4.17
-              arm64v8: grafana-9.4.17
+              amd64: grafana-9.4.17-1
+              arm64v8: grafana-9.4.17-1
             ubuntu:
               arm64v8: grafana-9.4.17
               amd64: grafana-9.4.17
@@ -346,8 +346,8 @@
               arm64v8: node-v19.5.0
           to:
             centos:
-              amd64: grafana-9.5.13
-              arm64v8: grafana-9.5.13
+              amd64: grafana-9.5.13-1
+              arm64v8: grafana-9.5.13-1
             ubuntu:
               amd64: grafana-9.5.13
               arm64v8: grafana-9.5.13
@@ -384,8 +384,8 @@
         package:
           from:
             centos:
-              amd64: grafana-9.5.13
-              arm64v8: grafana-9.5.13
+              amd64: grafana-9.5.13-1
+              arm64v8: grafana-9.5.13-1
             ubuntu:
               amd64: grafana-9.5.13
               arm64v8: grafana-9.5.13
@@ -396,8 +396,8 @@
               arm64v8: node-v19.6.0
           to:
             centos:
-              amd64: grafana-10.0.0
-              arm64v8: grafana-10.0.0
+              amd64: grafana-10.0.0-1
+              arm64v8: grafana-10.0.0-1
             ubuntu:
               amd64: grafana-10.0.0
               arm64v8: grafana-10.0.0
@@ -433,8 +433,8 @@
           state_index: true
         package:
           centos:
-            amd64: grafana-9.5.13
-            arm64v8: grafana-9.5.13
+            amd64: grafana-9.5.13-1
+            arm64v8: grafana-9.5.13-1
           ubuntu:
             amd64: grafana-9.5.13
             arm64v8: grafana-9.5.13
@@ -468,8 +468,8 @@
           state_index: true
         package:
           centos:
-            amd64: grafana-9.5.13
-            arm64v8: grafana-9.5.13
+            amd64: grafana-9.5.13-1
+            arm64v8: grafana-9.5.13-1
           ubuntu:
             amd64: grafana-9.5.13
             arm64v8: grafana-9.5.13

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -3,19 +3,23 @@
   description: |
     Installation of a vulnerable package
       macos: 
-      Used Package: Node 17.0.1 - PKG Format
-      CVES:
-        amd64: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
-        arm64v8: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
+        Used Packages: Node 17.0.1 - PKG Format
+        CVES:
+          amd64: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
+          arm64v8: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       windows:
-        Used Package: Node 17.0.1 - Exe Format 
+        Used Packages: Node 17.0.1 - Exe Format 
         CVE: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
-        Used Package Mysql 5.5.20 - .deb Format
-        CVE: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"]
+        Used Packages: Mysql 5.5.20 and Grafana 8.5.5 - .deb Format
+        CVE: 
+          amd64: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"],
+          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
       centos:
-        Used Package Openjdk 1.6.0 - .rpm Format
-        CVE: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-2405", "CVE-2014-1876", "CVE-2014-0462", "CVE-2012-5373", "CVE-2012-2739"]
+        Used Packages: Openjdk 1.6.0 and Grafana 8.5.5 - .rpm Format
+        CVE: 
+          amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-2405", "CVE-2014-1876", "CVE-2014-0462", "CVE-2012-5373", "CVE-2012-2739"],
+          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -27,8 +31,10 @@
         package:
           centos:
             amd64: openjdk-1.6.0
+            arm64v8: grafana-8.5.5
           ubuntu:
             amd64: mysql-5.5.20
+            arm64v8: grafana-8.5.5
           windows:
             amd64: node-v17.0.1
           macos:
@@ -39,22 +45,23 @@
   description: |
     Removal of a vulnerable package
       macos: 
-          Used Package: Node 17.0.1 - PKG Format
-          CVES Expected to mitigate:
-            ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
+        Used Packages: Node 17.0.1 - PKG Format
+        CVES Expected to mitigate:
+          ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       windows:
-        Used Package: Node 17.0.1 - Exe Format 
-
+        Used Packages: Node 17.0.1 - Exe Format 
         CVES Expected to mitigate: 
           ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
-        Used Package Mysql 5.5.20 - .deb Format
+        Used Packages: Mysql 5.5.20 and Grafana 8.5.5 - .deb Format
         CVES Expected to mitigate:
-          ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"]
+          amd64: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"],
+          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
       centos:
-        Used Package Openjdk 1.6.0 - .rpm Format
+        Used Packages: Openjdk 1.6.0 and Grafana 8.5.5 - .rpm Format
         CVE Expected to mitigate:
-          ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-2405", "CVE-2014-1876", "CVE-2014-0462", "CVE-2012-5373", "CVE-2012-2739"]
+          amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-2405", "CVE-2014-1876", "CVE-2014-0462", "CVE-2012-5373", "CVE-2012-2739"],
+          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -66,8 +73,10 @@
         package:
           centos:
             amd64: openjdk-1.6.0
+            arm64v8: grafana-8.5.5
           ubuntu:
             amd64: mysql-5.5.20
+            arm64v8: grafana-8.5.5
           windows:
             amd64: node-v17.0.1
           macos:
@@ -78,19 +87,23 @@
   description: |
     Upgrade of a vulnerable package which maintain vulnerability
     macos: 
-        Used Package: Node 17.1.0 - PKG Format
-        CVES:
-          amd64: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
-          arm64v8: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
+      Used Packages: Node 17.1.0 - PKG Format
+      CVES:
+        amd64: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
+        arm64v8: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
     windows:
-      Used Package: Node 17.1.0 - Exe Format 
-      "CVE": ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
+      Used Packages: Node 17.1.0 - Exe Format 
+      CVE: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
     ubuntu:
-      Used Package Mysql 5.5.21 - .deb Format
-      CVE: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"]
+      Used Packages: Mysql 5.5.21 and Grafana 8.5.6 - .deb Format
+      CVE: 
+        amd64: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"],
+        arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
     centos:
-      Used Package Openjdk 1.7.0 - .rpm Format
-      CVE: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-8873", "CVE-2014-2483", "CVE-2014-1876", "CVE-2013-2461", "CVE-2012-5373", "CVE-2012-2739"]
+      Used Packages: Openjdk 1.7.0 and Grafana 8.5.6 - .rpm Format
+      CVE: 
+        amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-8873", "CVE-2014-2483", "CVE-2014-1876", "CVE-2013-2461", "CVE-2012-5373", "CVE-2012-2739"],
+        arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions:
     tasks:
       - operation: install_package
@@ -101,8 +114,10 @@
         package:
           centos:
             amd64: openjdk-1.6.0
+            arm64v8: grafana-8.5.5
           ubuntu:
             amd64: mysql-5.5.20
+            arm64v8: grafana-8.5.5
           windows:
             amd64: node-v17.0.1
           macos:
@@ -119,8 +134,10 @@
           from:
             centos:
               amd64: openjdk-1.6.0
+              arm64v8: grafana-8.5.5
             ubuntu:
               amd64: mysql-5.5.20
+              arm64v8: grafana-8.5.5
             windows:
               amd64: node-v17.0.1
             macos:
@@ -129,8 +146,10 @@
           to:
             centos:
               amd64: openjdk-1.7.0
+              arm64v8: grafana-8.5.6
             ubuntu:
               amd64: mysql-5.5.21
+              arm64v8: grafana-8.5.6
             windows:
               amd64: node-v17.1.0
             macos:
@@ -142,17 +161,21 @@
   description: |
     Upgrade of a vulnerable package which include a new vulnerability
     macos: 
-        Used Package: Node 18.11.0 - PKG Format
-        CVES:  ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-32222"],
+      Used Packages: Node 18.11.0 - PKG Format
+      CVES: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-32222"],
     windows:
-      Used Package: Node 18.0.0 - Exe Format 
-      "CVE": ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30589", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32223", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
+      Used Packages: Node 18.0.0 - Exe Format 
+      CVE: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30589", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32223", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
-      Used Package Mysql 5.5.19 - .deb Format
-      CVE: ["CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2023-22007", "CVE-2023-22028", "CVE-2021-2356", "CVE-2022-21417", "CVE-2022-21444", "CVE-2023-21980", "CVE-2023-21977"]
+      Used Packages: Mysql 5.5.19 and Grafana 9.1.1 - .deb Format
+      CVE: 
+        amd64: ["CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2023-22007", "CVE-2023-22028", "CVE-2021-2356", "CVE-2022-21417", "CVE-2022-21444", "CVE-2023-21980", "CVE-2023-21977"],
+        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
     centos:
-      Used Package Openjdk 1.7.0 - .rpm Format
-      CVE: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-8873", "CVE-2014-2483", "CVE-2014-1876", "CVE-2013-2461", "CVE-2012-5373", "CVE-2012-2739"]
+      Used Packages: Openjdk 1.7.0 and Grafana 9.1.1 - .rpm Format
+      CVE: 
+        amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-8873", "CVE-2014-2483", "CVE-2014-1876", "CVE-2013-2461", "CVE-2012-5373", "CVE-2012-2739"],
+        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -165,8 +188,10 @@
           from:
             centos:
               amd64: openjdk-1.6.0
+              arm64v8: grafana-8.5.6
             ubuntu:
               amd64: mysql-5.5.18
+              arm64v8: grafana-8.5.6
             windows:
               amd64: node-v17.1.0
             macos:
@@ -175,8 +200,10 @@
           to:
             centos:
               amd64: openjdk-1.7.0
+              arm64v8: grafana-9.1.1
             ubuntu:
               amd64: mysql-5.5.19
+              arm64v8: grafana-9.1.1
             windows:
               amd64: node-v18.0.0
             macos:
@@ -190,17 +217,21 @@
     new ones
 
     macos: 
-        Used Package: Node 18.12.0 - PKG Format
-        "CVE": ["CVE-2023-44487", "CVE-2023-38552", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-23936", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-3786", "CVE-2022-3602"],
+      Used Packages: Node 18.12.0 - PKG Format
+      CVE: ["CVE-2023-44487", "CVE-2023-38552", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-23936", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-3786", "CVE-2022-3602"],
     windows:
-      Used Package: Node 18.1.0 - Exe Format 
-      "CVE": ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
+      Used Packages: Node 18.1.0 - Exe Format 
+      CVE: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
-      Used Package Mysql 5.5.19 - .deb Format
-      CVE: ["CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2023-22007", "CVE-2023-22028", "CVE-2021-2356", "CVE-2022-21417", "CVE-2022-21444", "CVE-2023-21980", "CVE-2023-21977"]
+      Used Packages: Mysql 5.5.19 - .deb Format
+      CVE: 
+        amd64: ["CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2023-22007", "CVE-2023-22028", "CVE-2021-2356", "CVE-2022-21417", "CVE-2022-21444", "CVE-2023-21980", "CVE-2023-21977"],
+        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
     centos:
-      Used Package Openjdk 1.8.0 - .rpm Format
-      CVE: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2021-20264", "CVE-2014-1876", "CVE-2012-2739"]
+      Used Packages: Openjdk 1.8.0 - .rpm Format
+      CVE: 
+        amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2021-20264", "CVE-2014-1876", "CVE-2012-2739"],
+        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -213,8 +244,10 @@
           from:
             centos:
               amd64: openjdk-1.7.0
+              arm64v8: grafana-8.5.6
             ubuntu:
               amd64: mysql-5.5.18
+              arm64v8: grafana-8.5.6
             windows:
               amd64: node-v18.0.0
             macos:
@@ -223,8 +256,10 @@
           to:
             centos:
               amd64: openjdk-1.8.0
+              arm64v8: grafana-9.1.1
             ubuntu:
               amd64: mysql-5.5.19
+              arm64v8: grafana-9.1.1
             windows:
               amd64: node-v18.1.0
             macos:
@@ -236,17 +271,17 @@
   description: |
     Upgrade of a vulnerable which cease to be vulnerable
     macos: 
-        Used Package: Node 19.5.0 - PKG Format
-        "CVE": [],
+      Used Packages: Node 19.5.0 - PKG Format
+      CVE: [],
     windows:
-      Used Package: Node 19.5.0 - Exe Format 
-      "CVE": [],
+      Used Packages: Node 19.5.0 - Exe Format 
+      CVE: [],
     ubuntu:
-      Used Package Grafana 9.4.17 - .deb Format
-      CVE: []
+      Used Packages: Grafana 9.4.17 - .deb Format
+      CVE: [],
     centos:
-      Used Package Grafana 9.4.17 - .rpm Format
-      CVE: []
+      Used Packages: Grafana 9.4.17 - .rpm Format
+      CVE: [],
   preconditions: null
   body:
     tasks:
@@ -286,17 +321,17 @@
   description: |
     Upgrade of a non vulnerable package to non vulnerable
       macos: 
-          Used Package: Node 19.5.0 - PKG Format
-          "CVE": [],
+        Used Packages: Node 19.5.0 - PKG Format
+        CVE: [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format 
-        "CVE": [],
+        Used Packages: Node 19.5.0 - Exe Format 
+        CVE: [],
       ubuntu:
-        Used Package Grafana 9.5.13 - .deb Format
-        CVE: []
+        Used Packages: Grafana 9.5.13 - .deb Format
+        CVE: [],
       centos:
-        Used Package Grafana 9.5.13 - .rpm Format
-        CVE: []
+        Used Packages: Grafana 9.5.13 - .rpm Format
+        CVE: [],
   preconditions:
     tasks:
       - operation: install_package
@@ -345,16 +380,16 @@
   description: |
     Upgrade to non vulnerable package to vulnerable
       macos: 
-          Used Package: Node 20.0.0 - PKG Format
-          "CVE": ["CVE-2023-44487", "CVE-2023-39332", "CVE-2023-39331", "CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32558", "CVE-2023-32006", "CVE-2023-32005", "CVE-2023-32004", "CVE-2023-32003", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30586", "CVE-2023-30585", "CVE-2023-30581"],
+        Used Packages: Node 20.0.0 - PKG Format
+        CVE: ["CVE-2023-44487", "CVE-2023-39332", "CVE-2023-39331", "CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32558", "CVE-2023-32006", "CVE-2023-32005", "CVE-2023-32004", "CVE-2023-32003", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30586", "CVE-2023-30585", "CVE-2023-30581"],
       windows:
-        Used Package: Node 20.5.1 - Exe Format 
-        "CVE": ["CVE-2023-44487", "CVE-2023-39332", "CVE-2023-39331", "CVE-2023-38552"],
+        Used Packages: Node 20.5.1 - Exe Format 
+        CVE: ["CVE-2023-44487", "CVE-2023-39332", "CVE-2023-39331", "CVE-2023-38552"],
       ubuntu:
-        Used Package Grafana 9.5.13 - .deb Format
+        Used Packages: Grafana 10.0.0 - .deb Format
         CVE: ["CVE-2023-4822", "CVE-2023-4399"],
       centos:
-        Used Package Grafana 9.5.13 - .rpm Format
+        Used Packages: Grafana 10.0.0 - .rpm Format
         CVE: ["CVE-2023-4822", "CVE-2023-4399"],
   preconditions: null
   body:
@@ -367,10 +402,11 @@
         package:
           from:
             centos:
-              amd64: firefox-91.13.0
-              arm64v8: grafana-8.5.5
+              amd64: grafana-9.4.17
+              arm64v8: grafana-9.4.17
             ubuntu:
-              amd64: grafana-8.5.5
+              amd64: grafana-9.4.17
+              arm64v8: grafana-9.4.17
             windows:
               amd64: node-v19.6.0
             macos:
@@ -378,10 +414,11 @@
               arm64v8: node-v19.6.0
           to:
             centos:
-              amd64: firefox-91.13.0
-              arm64v8: grafana-8.5.5
+              amd64: grafana-10.0.0
+              arm64v8: grafana-10.0.0
             ubuntu:
-              amd64: grafana-8.5.5
+              amd64: grafana-10.0.0
+              arm64v8: grafana-10.0.0
             windows:
               amd64: node-v20.5.1
             macos:
@@ -393,17 +430,17 @@
   description: |
     Installation of a non vulnerable package
       macos: 
-          Used Package: Node 19.5.0 - PKG Format
-          "CVE": [],
+        Used Packages: Node 19.5.0 - PKG Format
+        CVE: [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format 
-        "CVE": [],
+        Used Packages: Node 19.5.0 - Exe Format 
+        CVE: [],
       ubuntu:
-        Used Package Grafana 9.5.13 - .deb Format
-        CVE: []
+        Used Packages: Grafana 9.5.13 - .deb Format
+        CVE: [],
       centos:
-        Used Package Grafana 9.5.13 - .rpm Format
-        CVE: []
+        Used Packages: Grafana 9.5.13 - .rpm Format
+        CVE: [],
   preconditions: null
   body:
     tasks:
@@ -429,17 +466,17 @@
   description: |
     Removal of a non vulnerable package
       macos: 
-          Used Package: Node 19.5.0 - PKG Format
-          "CVE": [],
+        Used Packages: Node 19.5.0 - PKG Format
+        CVE: [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format 
-        "CVE": [],
+        Used Packages: Node 19.5.0 - Exe Format 
+        CVE: [],
       ubuntu:
-        Used Package Grafana 9.5.13 - .deb Format
+        Used Packages: Grafana 9.5.13 - .deb Format
         CVE: []
       centos:
-        Used Package Grafana 9.5.13 - .rpm Format
-        CVE: []
+        Used Packages: Grafana 9.5.13 - .rpm Format
+        CVE: [],
   body:
     tasks:
       - operation: remove_package

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -11,15 +11,11 @@
         Used Packages: Node 17.0.1 - Exe Format 
         CVE: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
-        Used Packages: Mysql 5.5.20 and Grafana 8.5.5 - .deb Format
-        CVE: 
-          amd64: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"],
-          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
+        Used Packages: Grafana 8.5.5 - .deb Format
+        CVE: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
       centos:
-        Used Packages: Openjdk 1.6.0 and Grafana 8.5.5 - .rpm Format
-        CVE: 
-          amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-2405", "CVE-2014-1876", "CVE-2014-0462", "CVE-2012-5373", "CVE-2012-2739"],
-          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
+        Used Packages: Grafana 8.5.5 - .rpm Format
+        CVE: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -30,10 +26,10 @@
           state_index: true
         package:
           centos:
-            amd64: openjdk-1.6.0
+            amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
           ubuntu:
-            amd64: mysql-5.5.20
+            amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
           windows:
             amd64: node-v17.0.1
@@ -53,15 +49,13 @@
         CVES Expected to mitigate: 
           ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
-        Used Packages: Mysql 5.5.20 and Grafana 8.5.5 - .deb Format
+        Used Packages: Grafana 8.5.5 - .deb Format
         CVES Expected to mitigate:
-          amd64: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"],
-          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
+          ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
       centos:
-        Used Packages: Openjdk 1.6.0 and Grafana 8.5.5 - .rpm Format
+        Used Packages: Grafana 8.5.5 - .rpm Format
         CVE Expected to mitigate:
-          amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-2405", "CVE-2014-1876", "CVE-2014-0462", "CVE-2012-5373", "CVE-2012-2739"],
-          arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
+          ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -72,10 +66,10 @@
           state_index: true
         package:
           centos:
-            amd64: openjdk-1.6.0
+            amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
           ubuntu:
-            amd64: mysql-5.5.20
+            amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
           windows:
             amd64: node-v17.0.1
@@ -95,15 +89,11 @@
       Used Packages: Node 17.1.0 - Exe Format 
       CVE: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
     ubuntu:
-      Used Packages: Mysql 5.5.21 and Grafana 8.5.6 - .deb Format
-      CVE: 
-        amd64: ["CVE-2023-22028", "CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2021-2356", "CVE-2020-15358", "CVE-2020-14852", "CVE-2020-14846", "CVE-2020-14845", "CVE-2020-14839", "CVE-2020-14837", "CVE-2020-14830"],
-        arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
+      Used Packages: Grafana 8.5.6 - .deb Format
+      CVE: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
     centos:
-      Used Packages: Openjdk 1.7.0 and Grafana 8.5.6 - .rpm Format
-      CVE: 
-        amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-8873", "CVE-2014-2483", "CVE-2014-1876", "CVE-2013-2461", "CVE-2012-5373", "CVE-2012-2739"],
-        arm64v8: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
+      Used Packages: Grafana 8.5.6 - .rpm Format
+      CVE: ["CVE-2023-2183", "CVE-2023-1410", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-31107", "CVE-2022-31097", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions:
     tasks:
       - operation: install_package
@@ -113,10 +103,10 @@
           state_index: true
         package:
           centos:
-            amd64: openjdk-1.6.0
+            amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
           ubuntu:
-            amd64: mysql-5.5.20
+            amd64: grafana-8.5.5
             arm64v8: grafana-8.5.5
           windows:
             amd64: node-v17.0.1
@@ -133,10 +123,10 @@
         package:
           from:
             centos:
-              amd64: openjdk-1.6.0
+              amd64: grafana-8.5.5
               arm64v8: grafana-8.5.5
             ubuntu:
-              amd64: mysql-5.5.20
+              amd64: grafana-8.5.5
               arm64v8: grafana-8.5.5
             windows:
               amd64: node-v17.0.1
@@ -145,10 +135,10 @@
               arm64v8: node-v17.0.1
           to:
             centos:
-              amd64: openjdk-1.7.0
+              amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
             ubuntu:
-              amd64: mysql-5.5.21
+              amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
             windows:
               amd64: node-v17.1.0
@@ -167,15 +157,11 @@
       Used Packages: Node 18.0.0 - Exe Format 
       CVE: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30589", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32223", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
-      Used Packages: Mysql 5.5.19 and Grafana 9.1.1 - .deb Format
-      CVE: 
-        amd64: ["CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2023-22007", "CVE-2023-22028", "CVE-2021-2356", "CVE-2022-21417", "CVE-2022-21444", "CVE-2023-21980", "CVE-2023-21977"],
-        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
+      Used Packages: Grafana 9.1.1 - .deb Format
+      CVE: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
     centos:
-      Used Packages: Openjdk 1.7.0 and Grafana 9.1.1 - .rpm Format
-      CVE: 
-        amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2014-8873", "CVE-2014-2483", "CVE-2014-1876", "CVE-2013-2461", "CVE-2012-5373", "CVE-2012-2739"],
-        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
+      Used Packages: Grafana 9.1.1 - .rpm Format
+      CVE: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -187,10 +173,10 @@
         package:
           from:
             centos:
-              amd64: openjdk-1.6.0
+              amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
             ubuntu:
-              amd64: mysql-5.5.18
+              amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
             windows:
               amd64: node-v17.1.0
@@ -199,10 +185,10 @@
               arm64v8: node-v17.1.0
           to:
             centos:
-              amd64: openjdk-1.7.0
+              amd64: grafana-9.1.1
               arm64v8: grafana-9.1.1
             ubuntu:
-              amd64: mysql-5.5.19
+              amd64: grafana-9.1.1
               arm64v8: grafana-9.1.1
             windows:
               amd64: node-v18.0.0
@@ -223,15 +209,11 @@
       Used Packages: Node 18.1.0 - Exe Format 
       CVE: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
-      Used Packages: Mysql 5.5.19 - .deb Format
-      CVE: 
-        amd64: ["CVE-2023-22026", "CVE-2023-22015", "CVE-2023-22007", "CVE-2023-21980", "CVE-2023-21977", "CVE-2022-21444", "CVE-2022-21417", "CVE-2021-22570", "CVE-2023-22007", "CVE-2023-22028", "CVE-2021-2356", "CVE-2022-21417", "CVE-2022-21444", "CVE-2023-21980", "CVE-2023-21977"],
-        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
+      Used Packages: Grafana 9.1.1 - .deb Format
+      CVE: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
     centos:
-      Used Packages: Openjdk 1.8.0 - .rpm Format
-      CVE: 
-        amd64: ["CVE-2023-21967", "CVE-2023-21954", "CVE-2023-21939", "CVE-2023-21938", "CVE-2023-21937", "CVE-2023-21930", "CVE-2021-20264", "CVE-2014-1876", "CVE-2012-2739"],
-        arm64v8: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
+      Used Packages: Grafana 9.1.1 - .rpm Format
+      CVE: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
     tasks:
@@ -243,10 +225,10 @@
         package:
           from:
             centos:
-              amd64: openjdk-1.7.0
+              amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
             ubuntu:
-              amd64: mysql-5.5.18
+              amd64: grafana-8.5.6
               arm64v8: grafana-8.5.6
             windows:
               amd64: node-v18.0.0
@@ -255,10 +237,10 @@
               arm64v8: node-v18.11.0
           to:
             centos:
-              amd64: openjdk-1.8.0
+              amd64: grafana-9.1.1
               arm64v8: grafana-9.1.1
             ubuntu:
-              amd64: mysql-5.5.19
+              amd64: grafana-9.1.1
               arm64v8: grafana-9.1.1
             windows:
               amd64: node-v18.1.0
@@ -293,11 +275,11 @@
         package:
           from:
             centos:
-              amd64: grafana-9.2.0
-              arm64v8: grafana-9.2.0
+              amd64: grafana-9.1.1
+              arm64v8: grafana-9.1.1
             ubuntu:
-              amd64: grafana-9.2.0
-              arm64v8: grafana-9.2.0
+              amd64: grafana-9.1.1
+              arm64v8: grafana-9.1.1
             windows:
               amd64: node-v18.1.0
             macos:
@@ -402,11 +384,11 @@
         package:
           from:
             centos:
-              amd64: grafana-9.4.17
-              arm64v8: grafana-9.4.17
+              amd64: grafana-9.5.13
+              arm64v8: grafana-9.5.13
             ubuntu:
-              amd64: grafana-9.4.17
-              arm64v8: grafana-9.4.17
+              amd64: grafana-9.5.13
+              arm64v8: grafana-9.5.13
             windows:
               amd64: node-v19.6.0
             macos:


### PR DESCRIPTION
# Description

| Related Issue |
| --- |
| https://github.com/wazuh/wazuh-qa/issues/5103 |
| https://github.com/wazuh/wazuh-qa/issues/5098 |

`Grafana (Enterprise)` packages do not generate vulnerabilities due to the format it uses. However, `Grafana (OSS)` does generate vulnerabilities. It is necessary to change the packages used, add the missing tests for `arm64v8` and verify that they work correctly.

---

## Testing Performed

| OS |
| --- |
| Ubuntu |
| CentOS 7 |

Build: https://ci.wazuh.info/job/Wazuh_QA_environment/1016/

The tests have been passed manually using the VMs of the build. The results are in the comments.
