### PR TITLE
Fixed centos AMI users

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -231,19 +231,19 @@ aws:
   linux-centos-7-amd64:
     ami: ami-0aedf6b1cb669b4c7
     zone: us-east-1
-    user: ec2-user
+    user: centos
   linux-centos-7-arm64:
     ami: ami-08dbbdbfc4fa2f393
     zone: us-east-1
-    user: ec2-user
+    user: centos
   linux-centos-8-amd64:
     ami: ami-0ee534f954d1b2c98
     zone: us-east-1
-    user: ec2-user
+    user: centos
   linux-centos-8-arm64:
-    ami: ami-0c2b701a4792b179b
+    ami: ami-012947942cdc60db6
     zone: us-east-1
-    user: ec2-user
+    user: centos
   linux-centos-9-amd64:
     ami: ami-0259c451b16b72e24
     zone: us-east-1

--- a/deployability/modules/allocation/static/specs/size.yml
+++ b/deployability/modules/allocation/static/specs/size.yml
@@ -26,7 +26,7 @@ aws:
     amd64:
       type: t3a.medium
     arm64:
-      type: c7gn.medium
+      type: a1.xlarge
   large:
     amd64:
       type: c5ad.xlarge


### PR DESCRIPTION
Tests:

Centos 7 AMD:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --composite-name linux-centos-7-amd64 --provider aws --size medium --label-team devops --label-termination-date "2024-03-20 21:00:00" --label-issue https://github.com/wazuh/wazuh-automation/issues/1546 --ssh-key ~/.ssh/allocation_test
[2024-03-21 10:34:43] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-21 10:34:43] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-21 10:34:43] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-21 10:34:44] [DEBUG] ALLOCATOR: Creating temp directory: /tmp/wazuh-qa/AWS-CCF95A9F-1F52-4158-B983-7864551367FD
[2024-03-21 10:35:01] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-CCF95A9F-1F52-4158-B983-7864551367FD directory to /tmp/wazuh-qa/i-0baea009931f818b3
[2024-03-21 10:35:02] [INFO] ALLOCATOR: Instance i-0baea009931f818b3 created.
[2024-03-21 10:35:03] [INFO] ALLOCATOR: Instance i-0baea009931f818b3 started.
[2024-03-21 10:35:04] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/i-0baea009931f818b3/inventory.yml
[2024-03-21 10:35:04] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/i-0baea009931f818b3/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-0baea009931f818b3/inventory.yml
ansible_host: ec2-3-93-164-223.compute-1.amazonaws.com
ansible_password: None
ansible_port: 2200
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: centos
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test -p 2200 centos@ec2-3-93-164-223.compute-1.amazonaws.com
The authenticity of host '[ec2-3-93-164-223.compute-1.amazonaws.com]:2200 ([3.93.164.223]:2200)' can't be established.
ED25519 key fingerprint is SHA256:pcMveoAoe6pGnJFhBnJ5vk3O2OW6VuLUPCrWCNVIWFg.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-3-93-164-223.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
[centos@ip-172-31-27-251 ~]$ cat /etc/*release
CentOS Linux release 7.9.2009 (Core)
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

CentOS Linux release 7.9.2009 (Core)
CentOS Linux release 7.9.2009 (Core)
[centos@ip-172-31-27-251 ~]$ exit
logout
Connection to ec2-3-93-164-223.compute-1.amazonaws.com closed.
```

Centos 7 ARM:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --composite-name linux-centos-7-arm64 --provider aws --size medium --label-team devops --label-termination-date "2024-03-20 21:00:00" --label-issue https://github.com/wazuh/wazuh-automation/issues/1546 --ssh-key ~/.ssh/allocation_test
[2024-03-21 10:35:21] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-21 10:35:21] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-21 10:35:21] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-21 10:35:22] [DEBUG] ALLOCATOR: Creating temp directory: /tmp/wazuh-qa/AWS-9DD60F96-AC1B-45E3-B6CA-A5CF407615A1
[2024-03-21 10:35:40] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-9DD60F96-AC1B-45E3-B6CA-A5CF407615A1 directory to /tmp/wazuh-qa/i-0fbe71f4266b6904b
[2024-03-21 10:35:40] [INFO] ALLOCATOR: Instance i-0fbe71f4266b6904b created.
[2024-03-21 10:35:41] [INFO] ALLOCATOR: Instance i-0fbe71f4266b6904b started.
[2024-03-21 10:35:42] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/i-0fbe71f4266b6904b/inventory.yml
[2024-03-21 10:35:42] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/i-0fbe71f4266b6904b/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-0fbe71f4266b6904b/inventory.yml
ansible_host: ec2-3-92-232-240.compute-1.amazonaws.com
ansible_password: None
ansible_port: 2200
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: centos
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test -p 2200 centos@ec2-3-92-232-240.compute-1.amazonaws.com
The authenticity of host '[ec2-3-92-232-240.compute-1.amazonaws.com]:2200 ([3.92.232.240]:2200)' can't be established.
ED25519 key fingerprint is SHA256:rDOXRXuAlXvA4AsVJUVFDnyYpJKDy5dE4lq5H5HNnGw.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-3-92-232-240.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Last failed login: Wed Nov  1 18:54:48 UTC 2023 on pts/0
There was 1 failed login attempt since the last successful login.
Last login: Wed Nov  1 18:53:12 2023 from ip-10-10-0-96.ec2.internal
[centos@ip-172-31-39-177 ~]$ cat /etc/*release
CentOS Linux release 7.9.2009 (AltArch)
NAME="CentOS Linux"
VERSION="7 (AltArch)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (AltArch)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7:server"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

CentOS Linux release 7.9.2009 (AltArch)
CentOS Linux release 7.9.2009 (AltArch)
[centos@ip-172-31-39-177 ~]$ exit
logout
Connection to ec2-3-92-232-240.compute-1.amazonaws.com closed.
```

Centos 8 AMD:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --composite-name linux-centos-8-amd64 --provider aws --size medium --label-team devops --label-termination-date "2024-03-20 21:00:00" --label-issue https://github.com/wazuh/wazuh-automation/issues/1546 --ssh-key ~/.ssh/allocation_test
[2024-03-21 10:35:59] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-21 10:35:59] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-21 10:35:59] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-21 10:36:00] [DEBUG] ALLOCATOR: Creating temp directory: /tmp/wazuh-qa/AWS-817E111F-647E-40CE-9479-3B0AD0FF7576
[2024-03-21 10:36:18] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-817E111F-647E-40CE-9479-3B0AD0FF7576 directory to /tmp/wazuh-qa/i-051d3507bd21486f6
[2024-03-21 10:36:18] [INFO] ALLOCATOR: Instance i-051d3507bd21486f6 created.
[2024-03-21 10:36:20] [INFO] ALLOCATOR: Instance i-051d3507bd21486f6 started.
[2024-03-21 10:36:20] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/i-051d3507bd21486f6/inventory.yml
[2024-03-21 10:36:20] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/i-051d3507bd21486f6/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-051d3507bd21486f6/inventory.yml
ansible_host: ec2-54-242-68-104.compute-1.amazonaws.com
ansible_password: None
ansible_port: 2200
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: centos
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test -p 2200 centos@ec2-54-242-68-104.compute-1.amazonaws.com
The authenticity of host '[ec2-54-242-68-104.compute-1.amazonaws.com]:2200 ([54.242.68.104]:2200)' can't be established.
ED25519 key fingerprint is SHA256:f+MpFKE/P/9yc2Ge6jf7PQMGMjPSIgYKnlrwJo38NQU.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-54-242-68-104.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Activate the web console with: systemctl enable --now cockpit.socket

[centos@ip-172-31-30-55 ~]$ cat /etc/*release
CentOS Stream release 8
NAME="CentOS Stream"
VERSION="8"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Stream 8"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 8"
REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
CentOS Stream release 8
CentOS Stream release 8
[centos@ip-172-31-30-55 ~]$ exit
logout
Connection to ec2-54-242-68-104.compute-1.amazonaws.com closed.
```

Centos 9 AMD:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --composite-name linux-centos-9-amd64 --provider aws --size medium --label-team devops --label-termination-date "2024-03-20 21:00:00" --label-issue https://github.com/wazuh/wazuh-automation/issues/1546 --ssh-key ~/.ssh/allocation_test
[2024-03-21 10:48:41] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-21 10:48:41] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-21 10:48:41] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-21 10:48:42] [DEBUG] ALLOCATOR: Creating temp directory: /tmp/wazuh-qa/AWS-0BADF028-54B7-42E5-A4EE-98AE66E153D3
[2024-03-21 10:48:59] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-0BADF028-54B7-42E5-A4EE-98AE66E153D3 directory to /tmp/wazuh-qa/i-0947ff4087e83db2e
[2024-03-21 10:48:59] [INFO] ALLOCATOR: Instance i-0947ff4087e83db2e created.
[2024-03-21 10:49:01] [INFO] ALLOCATOR: Instance i-0947ff4087e83db2e started.
[2024-03-21 10:49:01] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/i-0947ff4087e83db2e/inventory.yml
[2024-03-21 10:49:01] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/i-0947ff4087e83db2e/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-0947ff4087e83db2e/inventory.yml
ansible_host: ec2-3-90-213-149.compute-1.amazonaws.com
ansible_password: None
ansible_port: 2200
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: ec2-user
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test -p 2200 ec2-user@ec2-3-90-213-149.compute-1.amazonaws.com
The authenticity of host '[ec2-3-90-213-149.compute-1.amazonaws.com]:2200 ([3.90.213.149]:2200)' can't be established.
ED25519 key fingerprint is SHA256:WZZWLxVjzjOWtaSPx0Opxjrqj2LA/lSq5EiQ56gKqY0.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-3-90-213-149.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
[ec2-user@ip-172-31-25-231 ~]$ cat /etc/*release
CentOS Stream release 9
NAME="CentOS Stream"
VERSION="9"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="9"
PLATFORM_ID="platform:el9"
PRETTY_NAME="CentOS Stream 9"
ANSI_COLOR="0;31"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:centos:centos:9"
HOME_URL="https://centos.org/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux 9"
REDHAT_SUPPORT_PRODUCT_VERSION="CentOS Stream"
CentOS Stream release 9
CentOS Stream release 9
[ec2-user@ip-172-31-25-231 ~]$ exit
logout
Connection to ec2-3-90-213-149.compute-1.amazonaws.com closed.
```