### PR TITLE
Fix upgrade_package_remove_vulnerability test

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
@@ -163,10 +163,6 @@
         "amd64": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.x86_64.rpm",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.aarch64.rpm"
       },
-      "ubuntu": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana_9.2.0_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.2.0_arm64.deb"
-      },
       "uninstall_name": "grafana*"
     }
   },
@@ -194,10 +190,6 @@
       "centos": {
         "amd64": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.x86_64.rpm",
         "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.aarch64.rpm"
-      },
-      "ubuntu": {
-        "amd64": "https://dl.grafana.com/oss/release/grafana_9.4.17_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.4.17_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
@@ -114,20 +114,58 @@
     "package_name": "grafana",
     "package_version": "9.2.0",
     "CVE": [
-      "CVE-2021-25804",
-      "CVE-2021-25803",
-      "CVE-2021-25802",
-      "CVE-2021-25801",
-      "CVE-2020-26664"
+      "CVE-2023-3128",
+      "CVE-2023-22462",
+      "CVE-2023-2183",
+      "CVE-2023-1410",
+      "CVE-2023-1387",
+      "CVE-2023-0594",
+      "CVE-2023-0507",
+      "CVE-2022-39328",
+      "CVE-2022-39324",
+      "CVE-2022-39307",
+      "CVE-2022-39306",
+      "CVE-2022-23552",
+      "CVE-2022-23498"
     ],
     "urls": {
       "centos": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.2.0-1.x86_64.rpm",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise-9.2.0-1.aarch64.rpm"
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.aarch64.rpm"
       },
       "ubuntu": {
-        "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.0_amd64.deb",
-        "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.2.0_arm64.deb"
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.2.0_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.2.0_arm64.deb"
+      },
+      "uninstall_name": "grafana*"
+    }
+  },
+  "grafana-9.2.0-1": {
+    "package_name": "grafana",
+    "package_version": "9.2.0-1",
+    "CVE": [
+      "CVE-2023-3128",
+      "CVE-2023-22462",
+      "CVE-2023-2183",
+      "CVE-2023-1410",
+      "CVE-2023-1387",
+      "CVE-2023-0594",
+      "CVE-2023-0507",
+      "CVE-2022-39328",
+      "CVE-2022-39324",
+      "CVE-2022-39307",
+      "CVE-2022-39306",
+      "CVE-2022-23552",
+      "CVE-2022-23498"
+    ],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.2.0-1.aarch64.rpm"
+      },
+      "ubuntu": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.2.0_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.2.0_arm64.deb"
       },
       "uninstall_name": "grafana*"
     }
@@ -144,6 +182,22 @@
       "ubuntu": {
         "amd64": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.4.17_amd64.deb",
         "arm64v8": "https://dl.grafana.com/enterprise/release/grafana-enterprise_9.4.17_arm64.deb"
+      }
+    },
+    "uninstall_name": "grafana*"
+  },
+  "grafana-9.4.17-1": {
+    "package_name": "grafana",
+    "package_version": "9.4.17-1",
+    "CVE": [],
+    "urls": {
+      "centos": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.x86_64.rpm",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana-9.4.17-1.aarch64.rpm"
+      },
+      "ubuntu": {
+        "amd64": "https://dl.grafana.com/oss/release/grafana_9.4.17_amd64.deb",
+        "arm64v8": "https://dl.grafana.com/oss/release/grafana_9.4.17_arm64.deb"
       }
     },
     "uninstall_name": "grafana*"
@@ -299,9 +353,6 @@
       "macos": {
         "amd64": "https://nodejs.org/dist/v17.0.1/node-v17.0.1.pkg",
         "arm64v8": "https://nodejs.org/dist/v17.0.1/node-v17.0.1.pkg"
-      },
-      "windows": { 
-        "amd64": "https://nodejs.org/dist/v17.0.1/node-v17.0.1-x64.msi"
       }
     },
     "uninstall_name": "node*"
@@ -321,9 +372,6 @@
       "macos": {
         "amd64": "https://nodejs.org/dist/v17.1.0/node-v17.1.0.pkg",
         "arm64v8": "https://nodejs.org/dist/v17.1.0/node-v17.1.0.pkg"
-      },
-      "windows": { 
-        "amd64": "https://nodejs.org/dist/v17.1.0/node-v17.1.0-x64.msi"
       }
     },
     "uninstall_name": "node*"
@@ -360,42 +408,6 @@
       "macos": {
         "amd64": "https://nodejs.org/dist/v18.0.0/node-v18.0.0.pkg",
         "arm64v8": "https://nodejs.org/dist/v18.0.0/node-v18.0.0.pkg"
-      },
-      "windows": { 
-        "amd64": "https://nodejs.org/dist/v18.0.0/node-v18.0.0-x64.msi"
-      }
-    },
-    "uninstall_name": "node*"
-  },
-  "node-v18.1.0": {
-    "package_name": "node",
-    "package_version": "18.1.0",
-    "CVE": [
-      "CVE-2023-38552",
-      "CVE-2023-32559",
-      "CVE-2023-32006",
-      "CVE-2023-32002",
-      "CVE-2023-30590",
-      "CVE-2023-30588",
-      "CVE-2023-30585",
-      "CVE-2023-30581",
-      "CVE-2023-23920",
-      "CVE-2023-23919",
-      "CVE-2023-23918",
-      "CVE-2022-43548",
-      "CVE-2022-35256",
-      "CVE-2022-35255",
-      "CVE-2022-32222",
-      "CVE-2022-32215",
-      "CVE-2022-32214",
-      "CVE-2022-32213",
-      "CVE-2022-32212",
-      "CVE-2022-3786",
-      "CVE-2022-3602"
-    ],
-    "urls": {
-      "windows": { 
-        "amd64": "https://nodejs.org/dist/v18.1.0/node-v18.1.0-x64.msi"
       }
     },
     "uninstall_name": "node*"
@@ -524,22 +536,6 @@
     },
     "uninstall_name": "node*"
   },
-  "node-v20.5.1": {
-    "package_name": "node",
-    "package_version": "20.5.1",
-    "CVE": [
-      "CVE-2023-44487",
-      "CVE-2023-39332",
-      "CVE-2023-39331",
-      "CVE-2023-38552"
-    ],
-    "urls": {
-      "windows": {
-        "amd64": "https://nodejs.org/dist/v20.5.1/node-v20.5.1-x64.msi"
-      }
-    },
-    "uninstall_name": "node*"
-  },
   "lynx-2.8.8": {
     "package_name": "lynx",
     "package_version": "2.8.8-0.3.dev15.el7",
@@ -581,187 +577,5 @@
       }
     },
     "uninstall_name": "firefox*"
-  },
-  "mysql-5.5.18": {
-    "package_name": "mysql",
-    "package_version": "5.5.18",
-    "CVE": [
-      "CVE-2023-22028",
-      "CVE-2023-22026",
-      "CVE-2023-22015",
-      "CVE-2023-22007",
-      "CVE-2023-21980",
-      "CVE-2023-21977",
-      "CVE-2022-21444",
-      "CVE-2022-21417",
-      "CVE-2021-22570",
-      "CVE-2021-2356",
-      "CVE-2020-15358",
-      "CVE-2020-14852",
-      "CVE-2020-14846",
-      "CVE-2020-14845",
-      "CVE-2020-14839",
-      "CVE-2020-14837",
-      "CVE-2020-14830"
-    ],
-    "urls": {
-      "ubuntu": {
-        "amd64": "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.5.18-debian6.0-x86_64.deb"
-      }
-    },
-    "uninstall_name": "mysql*"
-  },
-  "mysql-5.5.19": {
-    "package_name": "mysql",
-    "package_version": "5.5.19",
-    "CVE": [
-      "CVE-2023-22026",
-      "CVE-2023-22015",
-      "CVE-2023-22007",
-      "CVE-2023-21980",
-      "CVE-2023-21977",
-      "CVE-2022-21444",
-      "CVE-2022-21417",
-      "CVE-2021-22570",
-      "CVE-2023-22007",
-      "CVE-2023-22028",
-      "CVE-2021-2356",
-      "CVE-2022-21417", 
-      "CVE-2022-21444", 
-      "CVE-2023-21980", 
-      "CVE-2023-21977"
-    ],
-    "urls": {
-      "ubuntu": {
-        "amd64": "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.5.19-debian6.0-x86_64.deb"
-      }
-    },
-    "uninstall_name": "mysql*"
-  },
-  "mysql-5.5.20": {
-    "package_name": "mysql",
-    "package_version": "5.5.20",
-    "CVE": [
-      "CVE-2023-22028",
-      "CVE-2023-22026",
-      "CVE-2023-22015",
-      "CVE-2023-22007",
-      "CVE-2023-21980",
-      "CVE-2023-21977",
-      "CVE-2022-21444",
-      "CVE-2022-21417",
-      "CVE-2021-22570",
-      "CVE-2021-2356",
-      "CVE-2020-15358",
-      "CVE-2020-14852",
-      "CVE-2020-14846",
-      "CVE-2020-14845",
-      "CVE-2020-14839",
-      "CVE-2020-14837",
-      "CVE-2020-14830"
-    ],
-    "urls": {
-      "ubuntu": {
-        "amd64": "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.5.20-debian6.0-x86_64.deb"
-      }
-    },
-    "uninstall_name": "mysql*"
-  },
-  "mysql-5.5.21": {
-    "package_name": "mysql",
-    "package_version": "5.5.21",
-    "CVE": [
-      "CVE-2023-22028",
-      "CVE-2023-22026",
-      "CVE-2023-22015",
-      "CVE-2023-22007",
-      "CVE-2023-21980",
-      "CVE-2023-21977",
-      "CVE-2022-21444",
-      "CVE-2022-21417",
-      "CVE-2021-22570",
-      "CVE-2021-2356",
-      "CVE-2020-15358",
-      "CVE-2020-14852",
-      "CVE-2020-14846",
-      "CVE-2020-14845",
-      "CVE-2020-14839",
-      "CVE-2020-14837",
-      "CVE-2020-14830"
-    ],
-    "urls": {
-      "ubuntu": {
-        "amd64": "https://downloads.mysql.com/archives/get/p/23/file/mysql-5.5.21-debian6.0-x86_64.deb"
-      }
-    },
-    "uninstall_name": "mysql*"
-  },
-  "openjdk-1.6.0": {
-    "package_name": "openjdk",
-    "package_version": "1.6.0",
-    "CVE": [
-      "CVE-2023-21967",
-      "CVE-2023-21954",
-      "CVE-2023-21939",
-      "CVE-2023-21938",
-      "CVE-2023-21937",
-      "CVE-2023-21930",
-      "CVE-2014-2405",
-      "CVE-2014-1876",
-      "CVE-2014-0462",
-      "CVE-2012-5373",
-      "CVE-2012-2739"
-    ],
-    "urls": {
-      "centos": {
-        "amd64": "https://buildlogs.centos.org/c7.1611.u/java-1.6.0-openjdk/20170112172413/1.6.0.41-1.13.13.1.el7_3.x86_64/java-1.6.0-openjdk-1.6.0.41-1.13.13.1.el7_3.x86_64.rpm"
-      }
-    },
-    "uninstall_name": "*openjdk*"
-  },
-  "openjdk-1.7.0": {
-    "package_name": "openjdk",
-    "package_version": "1.7.0",
-    "CVE": [
-      "CVE-2023-21967",
-      "CVE-2023-21954",
-      "CVE-2023-21939",
-      "CVE-2023-21938",
-      "CVE-2023-21937",
-      "CVE-2023-21930",
-      "CVE-2014-8873",
-      "CVE-2014-2483",
-      "CVE-2014-1876",
-      "CVE-2013-2461",
-      "CVE-2012-5373",
-      "CVE-2012-2739"
-    ],
-    "urls": {
-      "centos": {
-        "amd64": "https://buildlogs.centos.org/c7.1611.u/java-1.7.0-openjdk/20170509150838/1.7.0.141-2.6.10.1.el7_3.x86_64/java-1.7.0-openjdk-1.7.0.141-2.6.10.1.el7_3.x86_64.rpm"
-      }
-    },
-    "uninstall_name": "*openjdk*"
-  },
-  "openjdk-1.8.0": {
-    "package_name": "openjdk",
-    "package_version": "1.8.0",
-    "CVE": [
-      "CVE-2023-21967",
-      "CVE-2023-21954",
-      "CVE-2023-21939",
-      "CVE-2023-21938",
-      "CVE-2023-21937",
-      "CVE-2023-21930",
-      "CVE-2021-20264",
-      "CVE-2014-1876",
-      "CVE-2012-2739"
-    ],
-    "urls": {
-      "centos": {
-        "amd64": "https://buildlogs.centos.org/c7.1611.u/java-1.8.0-openjdk/20170720203731/1.8.0.141-1.b16.el7_3.x86_64/java-1.8.0-openjdk-1.8.0.141-1.b16.el7_3.x86_64.rpm"
-      }
-    },
-    "uninstall_name": "*openjdk*"
   }
 }

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -258,8 +258,8 @@
         package:
           from:
             centos:
-              amd64: grafana-9.2.0
-              arm64v8: grafana-9.2.0
+              amd64: grafana-9.2.0-1
+              arm64v8: grafana-9.2.0-1
             ubuntu:
               amd64: grafana-9.2.0
               arm64v8: grafana-9.2.0
@@ -270,8 +270,8 @@
               arm64v8: node-v18.12.0
           to:
             centos:
-              amd64: grafana-9.4.17
-              arm64v8: grafana-9.4.17
+              amd64: grafana-9.4.17-1
+              arm64v8: grafana-9.4.17-1
             ubuntu:
               arm64v8: grafana-9.4.17
               amd64: grafana-9.4.17


### PR DESCRIPTION
# Description

This PR aims to fix the `upgrade_package_remove_vulnerability` test from the vulnerability detector test cases, since it was not working correctly because it assumed that the Grafana package was installed in version 9.2.0, but since it was not installed, no vulnerabilities were generated and the test did not pass. In this PR the Grafana download links have been changed and another version required for CentOS systems has been added. It has not been added as a precondition to install the 9.2.0 package as this will be done as part of the development of this PR https://github.com/wazuh/wazuh-qa/pull/5135. 

## Testing performed

