### PR TITLE
Add `alert.json` to VD E2E test report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add alert.json file to Vulnerability Detector E2E test report ([#5105](https://github.com/wazuh/wazuh-qa/issues/5105)) \- (Framework)
+- Add alert.json file to Vulnerability Detector E2E test report ([#5147](https://github.com/wazuh/wazuh-qa/pull/5147)) \- (Framework)
 - Add documentation about markers for system tests ([#5080](https://github.com/wazuh/wazuh-qa/pull/5080)) \- (Documentation)
 - Add AWS Custom Buckets Integration tests ([#4675](https://github.com/wazuh/wazuh-qa/pull/4675)) \- (Framework + Tests)
 - Add Vulnerability Detector end to end tests ([#4878](https://github.com/wazuh/wazuh-qa/pull/4878)) \- (Framework + Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add alert.json file to Vulnerability Detector E2E test report ([#5105](https://github.com/wazuh/wazuh-qa/issues/5105)) \- (Framework)
 - Add documentation about markers for system tests ([#5080](https://github.com/wazuh/wazuh-qa/pull/5080)) \- (Documentation)
 - Add AWS Custom Buckets Integration tests ([#4675](https://github.com/wazuh/wazuh-qa/pull/4675)) \- (Framework + Tests)
 - Add Vulnerability Detector end to end tests ([#4878](https://github.com/wazuh/wazuh-qa/pull/4878)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/logs.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/logs.py
@@ -59,3 +59,18 @@ def get_hosts_logs(host_manager: HostManager, host_group: str = 'all') -> Dict[s
         host_logs[host] = host_manager.get_file_content(host, logs_filepath_os[host_os_name])
 
     return host_logs
+
+def get_hosts_alerts(host_manager: HostManager, host_group: str = 'all') -> Dict[str, str]:
+    """
+    Get the alerts in the alert.json file from the specified host group.
+
+    Parameters:
+    - host_manager (HostManager): An instance of the HostManager class for managing remote hosts.
+    - host_group (str, optional): The name of the host group where the files will be truncated.
+      Default is 'all'.
+    """
+    host_alerts = {}
+    for host in host_manager.get_group_hosts(host_group):
+        host_alerts[host] = host_manager.get_file_content(host, ALERTS_JSON_PATH)
+
+    return host_alerts

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/logs.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/logs.py
@@ -52,6 +52,9 @@ def get_hosts_logs(host_manager: HostManager, host_group: str = 'all') -> Dict[s
     - host_manager (HostManager): An instance of the HostManager class for managing remote hosts.
     - host_group (str, optional): The name of the host group where the files will be truncated.
       Default is 'all'.
+
+    Returns:
+    - host_logs (Dict[str, str]): Dictionary containing the logs from the ossec.log file of each host
     """
     host_logs = {}
     for host in host_manager.get_group_hosts(host_group):
@@ -60,17 +63,18 @@ def get_hosts_logs(host_manager: HostManager, host_group: str = 'all') -> Dict[s
 
     return host_logs
 
-def get_hosts_alerts(host_manager: HostManager, host_group: str = 'all') -> Dict[str, str]:
+def get_hosts_alerts(host_manager: HostManager) -> Dict[str, str]:
     """
     Get the alerts in the alert.json file from the specified host group.
 
     Parameters:
     - host_manager (HostManager): An instance of the HostManager class for managing remote hosts.
-    - host_group (str, optional): The name of the host group where the files will be truncated.
-      Default is 'all'.
+
+    Returns:
+    - host_alerts (Dict[str, str]): Dictionary containing the alerts from the alert.json file of each manager
     """
     host_alerts = {}
-    for host in host_manager.get_group_hosts(host_group):
+    for host in host_manager.get_group_hosts("manager"):
         host_alerts[host] = host_manager.get_file_content(host, ALERTS_JSON_PATH)
 
     return host_alerts

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -42,7 +42,7 @@ from typing import Generator, Dict
 
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.end_to_end.remote_operations_handler import launch_parallel_operations
-from wazuh_testing.end_to_end.logs import get_hosts_logs
+from wazuh_testing.end_to_end.logs import get_hosts_logs, get_hosts_alerts
 
 
 STYLE_PATH = os.path.join(os.path.dirname(__file__), '../../../deps/wazuh_testing/wazuh_testing/reporting/style.css')
@@ -61,17 +61,26 @@ def collect_e2e_environment_data(test_name, host_manager) -> None:
     """
     logging.info("Collecting environment data")
     environment_logs = get_hosts_logs(host_manager)
+    environment_alerts = get_hosts_alerts(host_manager)
 
     current_dir = os.path.dirname(__file__)
-    vulnerability_detector_logs_dir = os.path.join(current_dir, "logs")
-    tests_evidences_directory = os.path.join(str(vulnerability_detector_logs_dir), str(test_name))
+    vulnerability_detector_dir = os.path.join(current_dir, "logs")
+    tests_evidences_directory = os.path.join(str(vulnerability_detector_dir), str(test_name))
 
     for host in environment_logs.keys():
         logging.info(f"Collecting logs for {host}")
-        host_logs_name_evidence = host + "_ossec.log"
-        evidence_file = os.path.join(tests_evidences_directory, host_logs_name_evidence)
-        with open(evidence_file, 'w') as evidence_file:
-            evidence_file.write(environment_logs[host])
+        host_logs_name_evidence = host + "_ossec.log"        
+        evidence_log_file = os.path.join(tests_evidences_directory, host_logs_name_evidence)
+        with open(evidence_log_file, 'w') as evidence_log_file:
+            evidence_log_file.write(environment_logs[host])
+
+    for host in environment_alerts.keys():
+        logging.info(f"Collecting alerts for {host}")
+        if host.startswith("manager"):            
+            host_alerts_name_evidence = host + "_alert.json"
+            evidence_alert_file = os.path.join(tests_evidences_directory, host_alerts_name_evidence)
+            with open(evidence_alert_file, 'w') as evidence_alert_file:
+                evidence_alert_file.write(environment_alerts[host])
 
 
 def collect_evidences(test_name, evidences) -> None:

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -64,8 +64,8 @@ def collect_e2e_environment_data(test_name, host_manager) -> None:
     environment_alerts = get_hosts_alerts(host_manager)
 
     current_dir = os.path.dirname(__file__)
-    vulnerability_detector_dir = os.path.join(current_dir, "logs")
-    tests_evidences_directory = os.path.join(str(vulnerability_detector_dir), str(test_name))
+    vulnerability_detector_logs_dir = os.path.join(current_dir, "logs")
+    tests_evidences_directory = os.path.join(str(vulnerability_detector_logs_dir), str(test_name))
 
     for host in environment_logs.keys():
         logging.info(f"Collecting logs for {host}")

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -75,12 +75,11 @@ def collect_e2e_environment_data(test_name, host_manager) -> None:
             evidence_log_file.write(environment_logs[host])
 
     for host in environment_alerts.keys():
-        logging.info(f"Collecting alerts for {host}")
-        if host.startswith("manager"):            
-            host_alerts_name_evidence = host + "_alert.json"
-            evidence_alert_file = os.path.join(tests_evidences_directory, host_alerts_name_evidence)
-            with open(evidence_alert_file, 'w') as evidence_alert_file:
-                evidence_alert_file.write(environment_alerts[host])
+        logging.info(f"Collecting alerts for {host}")           
+        host_alerts_name_evidence = host + "_alert.json"
+        evidence_alert_file = os.path.join(tests_evidences_directory, host_alerts_name_evidence)
+        with open(evidence_alert_file, 'w') as evidence_alert_file:
+            evidence_alert_file.write(environment_alerts[host])
 
 
 def collect_evidences(test_name, evidences) -> None:


### PR DESCRIPTION
# Description

This PR aims to add the `alert.json` file to Vulnerability Detection E2E test report as well as the `ossec.log` and the test logs are attached. This will be useful since when the test indicates that the alert has not been found, we will be able to check if the alert has been triggered or not. For this purpose, a new function has been added to obtain the alerts from the `alert.json` file of the managers and the function in charge of collecting this information has been modified.

## Testing performed

In order to test the changes that have been made, the following environment has been released https://ci.wazuh.info/job/Wazuh_QA_environment/1025/. To avoid running the entire test and not spending so much time, only the `upgrade_package_remove_vulneraility` test has been run, which is currently expected to fail due to what is reported in this issue https://github.com/wazuh/wazuh-qa/issues/5104. When the test failed, a report was generated which indeed includes a file containing the `alert.json`, and is attached below:

![image](https://github.com/wazuh/wazuh-qa/assets/101177239/97ab04ef-dbbd-44c0-ad18-cd909b368985)


![image](https://github.com/wazuh/wazuh-qa/assets/101177239/2d690cdc-b134-4277-8a25-a5e8ad771c0a)

[report5105.zip](https://github.com/wazuh/wazuh-qa/files/14746364/report5105.zip)

