### PR TITLE
Fix in `remote_operations_handler.py` functions 

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
@@ -164,37 +164,43 @@ def install_package(host: str, operation_data: Dict[str, Dict], host_manager: Ho
     package_id = None
 
     if host_os_name in install_package_data:
-        if host_os_arch in install_package_data[host_os_name]:
-            package_id = install_package_data[host_os_name][host_os_arch]
-        else:
-            raise ValueError(f"Package for {host_os_name} and {host_os_arch} not found")
+        try:
+            if host_os_arch in install_package_data[host_os_name]:
+                package_id = install_package_data[host_os_name][host_os_arch]
+        
+                package_data = load_packages_metadata()[package_id]
+                package_url = package_data['urls'][host_os_name][host_os_arch]
 
-        package_data = load_packages_metadata()[package_id]
-        package_url = package_data['urls'][host_os_name][host_os_arch]
+                logging.info(f"Installing package on {host}")
+                logging.info(f"Package URL: {package_url}")
 
-        logging.info(f"Installing package on {host}")
-        logging.info(f"Package URL: {package_url}")
+                current_datetime = datetime.utcnow().isoformat()
 
-        current_datetime = datetime.utcnow().isoformat()
+                host_manager.install_package(host, package_url, system)
 
-        host_manager.install_package(host, package_url, system)
+                logging.info(f"Package {package_url} installed on {host}")
 
-        logging.info(f"Package {package_url} installed on {host}")
+                logging.info(f"Package installed on {host}")
 
-        logging.info(f"Package installed on {host}")
+                results['checks']['all_successfull'] = True
 
-        results['checks']['all_successfull'] = True
+                wait_is_required = 'check' in operation_data and (operation_data['check']['alerts'] or
+                                                                operation_data['check']['state_index'] or
+                                                                operation_data['check']['no_alerts'] or
+                                                                operation_data['check']['no_indices'])
 
-        wait_is_required = 'check' in operation_data and (operation_data['check']['alerts'] or
-                                                          operation_data['check']['state_index'] or
-                                                          operation_data['check']['no_alerts'] or
-                                                          operation_data['check']['no_indices'])
+                if wait_is_required:
+                    wait_syscollector_and_vuln_scan(host_manager, host, operation_data, current_datetime)
 
-        if wait_is_required:
-            wait_syscollector_and_vuln_scan(host_manager, host, operation_data, current_datetime)
+                    check_vulnerability_alerts(results, operation_data['check'], current_datetime, host_manager, host,
+                                                package_data, operation='install')
+            
+            else:
+                logging.error(f"Package for {host_os_name} and {host_os_arch} not found")
+                
+        except Exception as e:
+            logging.critical(f"Error searching package: {e}")
 
-            check_vulnerability_alerts(results, operation_data['check'], current_datetime, host_manager, host,
-                                       package_data, operation='install')
     else:
         logging.info(f"No operation to perform on {host}")
 


### PR DESCRIPTION
# Description

This PR aims to make the necessary changes in the code to avoid that the Vulnerability Detector E2E tests do not continuing if any error occurs during the setup of some of the agents, that is to say, if any error occurs during this phase, the execution must continue to allow the development of the rest of the agents. For this purpose, some functions of the `remote_operations_handler.py` script have been modified, since the problem was detected in them because, in the event of an error, they terminated the execution of the function using `raise error`. They have been modified so that they do not terminate the execution but simply report the error and continue the process.

## Testing performed

