### PR TITLE
Filter alerts and logs by timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix timestamps alerts and logs filter ([#5157](https://github.com/wazuh/wazuh-qa/pull/5157)) \- (Framework + Tests)
 - Fix remote_operations_handler functions to Vulnerability Detector E2E tests ([#5155](https://github.com/wazuh/wazuh-qa/pull/5155)) \- (Framework)
 - Fix test_shutdown_message system test ([#5087](https://github.com/wazuh/wazuh-qa/pull/5087)) \- (Tests)
 - Include timeout to test_authd system tests ([#5083](https://github.com/wazuh/wazuh-qa/pull/5083)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -93,3 +93,25 @@ def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': '
                             json=data)
 
     return response.json()
+
+
+def delete_index(host_manager: HostManager, credentials: dict = {'user': 'admin', 'password': 'changeme'},
+                 index: str = 'wazuh-alerts*'):
+    """
+    Delete index from the Wazuh Indexer API.
+
+    Args:
+        host_manager: An instance of the HostManager class containing information about hosts.
+        credentials (Optional): A dictionary containing the Indexer credentials. Defaults to
+                                 {'user': 'admin', 'password': 'changeme'}.
+        index (Optional): The Indexer index name. Defaults to 'wazuh-alerts*'.
+    """
+    logging.info(f"Deleting {index} index")
+
+    url = f"https://{host_manager.get_master_ip()}:9200/{index}/"
+    headers = {
+        'Content-Type': 'application/json',
+    }
+
+    requests.delete(url=url, verify=False,
+                    auth=requests.auth.HTTPBasicAuth(credentials['user'], credentials['password']), headers=headers)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/regex.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/regex.py
@@ -46,10 +46,10 @@ REGEX_PATTERNS = {
         'parameters': ['HOST_NAME', 'CVE', 'PACKAGE_NAME', 'PACKAGE_VERSION', 'ARCHITECTURE']
     },
     'vuln_affected': {
-        'regex':  'CVE.*? affects.*"?'
+        'regex':  'CVE.* affects.*"?'
     },
     'vuln_mitigated': {
-        'regex': "The .* that affected .* was solved due to a package removal"
+        'regex': "The .* that affected .* was solved due to a package removal.*"
     }
 }
 

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
@@ -174,7 +174,7 @@ def install_package(host: str, operation_data: Dict[str, Dict], host_manager: Ho
                 logging.info(f"Installing package on {host}")
                 logging.info(f"Package URL: {package_url}")
 
-                current_datetime = datetime.now(timezone.utc).isoformat()[:-6]
+                current_datetime = datetime.now(timezone.utc).isoformat()[:-6]  # Delete timezone offset
                 host_manager.install_package(host, package_url, system)
 
                 logging.info(f"Package {package_url} installed on {host}")
@@ -250,7 +250,7 @@ def remove_package(host: str, operation_data: Dict[str, Dict], host_manager: Hos
 
                 package_data = load_packages_metadata()[package_id]
 
-                current_datetime = datetime.now(timezone.utc).isoformat()[:-6]
+                current_datetime = datetime.now(timezone.utc).isoformat()[:-6]  # Delete timezone offset
 
                 logging.info(f"Removing package on {host}")
                 if 'uninstall_name' in package_data:
@@ -347,7 +347,7 @@ def update_package(host: str, operation_data: Dict[str, Dict], host_manager: Hos
                 logging.info(f"Installing package on {host}")
                 logging.info(f"Package URL: {package_url_to}")
 
-                current_datetime = datetime.now(timezone.utc).isoformat()[:-6]
+                current_datetime = datetime.now(timezone.utc).isoformat()[:-6]  # Delete timezone offset
                 host_manager.install_package(host, package_url_to, system)
 
                 logging.info(f"Package {package_url_to} installed on {host}")
@@ -388,7 +388,7 @@ def launch_remote_sequential_operation_on_agent(agent: str, task_list: List[Dict
         host_manager (HostManager): An instance of the HostManager class containing information about hosts.
     """
     # Convert datetime to Unix timestamp (integer)
-    timestamp = datetime.now(timezone.utc).isoformat()[:-6]
+    timestamp = datetime.now(timezone.utc).isoformat()[:-6]  # Delete timezone offset
 
     if task_list:
         for task in task_list:

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
@@ -22,7 +22,7 @@ This program is a free software; you can redistribute it and/or modify it under 
 """
 import logging
 from typing import Dict, List
-from datetime import datetime
+from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor
 
 from wazuh_testing.end_to_end.waiters import wait_syscollector_and_vuln_scan
@@ -175,7 +175,7 @@ def install_package(host: str, operation_data: Dict[str, Dict], host_manager: Ho
         logging.info(f"Installing package on {host}")
         logging.info(f"Package URL: {package_url}")
 
-        current_datetime = datetime.utcnow().isoformat()
+        current_datetime = datetime.now(timezone.utc).isoformat()[:-6]
 
         host_manager.install_package(host, package_url, system)
 
@@ -246,7 +246,7 @@ def remove_package(host: str, operation_data: Dict[str, Dict], host_manager: Hos
 
         package_data = load_packages_metadata()[package_id]
 
-        current_datetime = datetime.utcnow().isoformat()
+        current_datetime = datetime.now(timezone.utc).isoformat()[:-6]
 
         logging.info(f"Removing package on {host}")
         if 'uninstall_name' in package_data:
@@ -335,7 +335,7 @@ def update_package(host: str, operation_data: Dict[str, Dict], host_manager: Hos
         logging.info(f"Installing package on {host}")
         logging.info(f"Package URL: {package_url_to}")
 
-        current_datetime = datetime.utcnow().isoformat()
+        current_datetime = datetime.now(timezone.utc).isoformat()[:-6]
         host_manager.install_package(host, package_url_to, system)
 
         logging.info(f"Package {package_url_to} installed on {host}")
@@ -369,7 +369,7 @@ def launch_remote_sequential_operation_on_agent(agent: str, task_list: List[Dict
         host_manager (HostManager): An instance of the HostManager class containing information about hosts.
     """
     # Convert datetime to Unix timestamp (integer)
-    timestamp = datetime.utcnow().isoformat()
+    timestamp = datetime.now(timezone.utc).isoformat()[:-6]
 
     if task_list:
         for task in task_list:

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
@@ -80,7 +80,8 @@ def wait_syscollector_and_vuln_scan(host_manager: HostManager, host: str,  opera
                                                [get_event_regex({'event': 'syscollector_scan_start'}),
                                                 get_event_regex({'event': 'syscollector_scan_end'})],
                                                [timeout_syscollector_scan, timeout_syscollector_scan],
-                                               host_manager.get_group_hosts('agent'))
+                                               host_manager.get_group_hosts('agent'),
+                                               greater_than_timestamp=current_datetime)
 
     truncate_remote_host_group_files(host_manager, host_manager.get_group_hosts('agent'))
 

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
@@ -45,7 +45,7 @@ def wait_until_vd_is_updated(host_manager: HostManager) -> None:
 
     monitoring_data = generate_monitoring_logs(host_manager, ["INFO: Vulnerability scanner module started"],
                                                [VD_FEED_UPDATE_TIMEOUT], host_manager.get_group_hosts('manager'))
-    monitoring_events_multihost(host_manager, monitoring_data)
+    monitoring_events_multihost(host_manager, monitoring_data, ignore_timeout_error=False)
 
 
 def wait_until_vuln_scan_agents_finished(host_manager: HostManager) -> None:
@@ -85,7 +85,7 @@ def wait_syscollector_and_vuln_scan(host_manager: HostManager, host: str,  opera
 
     truncate_remote_host_group_files(host_manager, host_manager.get_group_hosts('agent'))
 
-    monitoring_events_multihost(host_manager, monitoring_data)
+    monitoring_events_multihost(host_manager, monitoring_data, ignore_timeout_error=False)
 
     logging.info(f"Waiting for vulnerability scan to finish on {host}")
 

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -2,13 +2,13 @@
   id: install_package
   description: |
     Installation of a vulnerable package
-      macos: 
+      macos:
         Used Packages: Node 17.0.1 - PKG Format
         CVES:
           amd64: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
           arm64v8: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       windows:
-        Used Packages: Node 17.0.1 - Exe Format 
+        Used Packages: Node 17.0.1 - Exe Format
         CVE: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
         Used Packages: Grafana 8.5.5 - .deb Format
@@ -40,13 +40,13 @@
   id: remove_package
   description: |
     Removal of a vulnerable package
-      macos: 
+      macos:
         Used Packages: Node 17.0.1 - PKG Format
         CVES Expected to mitigate:
           ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       windows:
-        Used Packages: Node 17.0.1 - Exe Format 
-        CVES Expected to mitigate: 
+        Used Packages: Node 17.0.1 - Exe Format
+        CVES Expected to mitigate:
           ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
         Used Packages: Grafana 8.5.5 - .deb Format
@@ -80,13 +80,13 @@
   id: upgrade_package_maintain_vulnerability
   description: |
     Upgrade of a vulnerable package which maintain vulnerability
-    macos: 
+    macos:
       Used Packages: Node 17.1.0 - PKG Format
       CVES:
         amd64: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
         arm64v8: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
     windows:
-      Used Packages: Node 17.1.0 - Exe Format 
+      Used Packages: Node 17.1.0 - Exe Format
       CVE: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
     ubuntu:
       Used Packages: Grafana 8.5.6 - .deb Format
@@ -150,11 +150,11 @@
   id: upgrade_package_maintain_add_vulnerability
   description: |
     Upgrade of a vulnerable package which include a new vulnerability
-    macos: 
+    macos:
       Used Packages: Node 18.11.0 - PKG Format
       CVES: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-32222"],
     windows:
-      Used Packages: Node 18.0.0 - Exe Format 
+      Used Packages: Node 18.0.0 - Exe Format
       CVE: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30589", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32223", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
       Used Packages: Grafana 9.1.1 - .deb Format
@@ -195,24 +195,24 @@
             macos:
               amd64: node-v18.11.0
               arm64v8: node-v18.11.0
-    
+
 - case: 'Upgrade: Maintain and new vulnerability '
   id: upgrade_package_maintain_add_vulnerability
   description: >
     Upgrade of a vulnerable package which maintain vulnerabilities and include
     new ones
 
-    macos: 
+    macos:
       Used Packages: Node 18.12.0 - PKG Format
       CVE: ["CVE-2023-44487", "CVE-2023-38552", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-23936", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-3786", "CVE-2022-3602"],
     windows:
-      Used Packages: Node 18.1.0 - Exe Format 
+      Used Packages: Node 18.1.0 - Exe Format
       CVE: ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
-      Used Packages: Grafana 9.1.1 - .deb Format
-      CVE: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
+      Used Packages: Grafana 9.2.0 - .deb Format
+      CVE: ["CVE-2023-3128", "CVE-2023-22462", "CVE-2023-2183", "CVE-2023-1410", "CVE-2023-1387", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39328", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-23552", "CVE-2022-23498"],
     centos:
-      Used Packages: Grafana 9.1.1 - .rpm Format
+      Used Packages: Grafana 9.2.0 - .rpm Format
       CVE: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
   preconditions: null
   body:
@@ -225,11 +225,11 @@
         package:
           from:
             centos:
-              amd64: grafana-8.5.6-1
-              arm64v8: grafana-8.5.6-1
+              amd64: grafana-9.1.1-1
+              arm64v8: grafana-9.1.1-1
             ubuntu:
-              amd64: grafana-8.5.6
-              arm64v8: grafana-8.5.6
+              amd64: grafana-9.1.1
+              arm64v8: grafana-9.1.1
             windows:
               amd64: node-v18.0.0
             macos:
@@ -237,26 +237,26 @@
               arm64v8: node-v18.11.0
           to:
             centos:
-              amd64: grafana-9.1.1-1
-              arm64v8: grafana-9.1.1-1
+              amd64: grafana-9.2.0-1
+              arm64v8: grafana-9.2.0-1
             ubuntu:
-              amd64: grafana-9.1.1
-              arm64v8: grafana-9.1.1
+              amd64: grafana-9.2.0
+              arm64v8: grafana-9.2.0
             windows:
               amd64: node-v18.1.0
             macos:
               amd64: node-v18.12.0
               arm64v8: node-v18.12.0
-    
+
 - case: 'Upgrade: Cease vulnerability'
   id: upgrade_package_remove_vulnerability
   description: |
     Upgrade of a vulnerable which cease to be vulnerable
-    macos: 
+    macos:
       Used Packages: Node 19.5.0 - PKG Format
       CVE: [],
     windows:
-      Used Packages: Node 19.5.0 - Exe Format 
+      Used Packages: Node 19.5.0 - Exe Format
       CVE: [],
     ubuntu:
       Used Packages: Grafana 9.4.17 - .deb Format
@@ -275,11 +275,11 @@
         package:
           from:
             centos:
-              amd64: grafana-9.1.1-1
-              arm64v8: grafana-9.1.1-1
+              amd64: grafana-9.2.0-1
+              arm64v8: grafana-9.2.0-1
             ubuntu:
-              amd64: grafana-9.1.1
-              arm64v8: grafana-9.1.1
+              amd64: grafana-9.2.0
+              arm64v8: grafana-9.2.0
             windows:
               amd64: node-v18.1.0
             macos:
@@ -297,16 +297,16 @@
             macos:
               amd64: node-v19.5.0
               arm64v8: node-v19.5.0
-    
+
 - case: 'Upgrade: Non vulnerable to non vulnerable'
   id: upgrade_package_nonvulnerable_to_nonvulnerable
   description: |
     Upgrade of a non vulnerable package to non vulnerable
-      macos: 
+      macos:
         Used Packages: Node 19.5.0 - PKG Format
         CVE: [],
       windows:
-        Used Packages: Node 19.5.0 - Exe Format 
+        Used Packages: Node 19.5.0 - Exe Format
         CVE: [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -356,16 +356,16 @@
             macos:
               amd64: node-v19.6.0
               arm64v8: node-v19.6.0
-    
+
 - case: 'Upgrade: Non vulnerable to vulnerable package'
   id: upgrade_package_nonvulnerable_to_vulnerable
   description: |
     Upgrade to non vulnerable package to vulnerable
-      macos: 
+      macos:
         Used Packages: Node 20.0.0 - PKG Format
         CVE: ["CVE-2023-44487", "CVE-2023-39332", "CVE-2023-39331", "CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32558", "CVE-2023-32006", "CVE-2023-32005", "CVE-2023-32004", "CVE-2023-32003", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30586", "CVE-2023-30585", "CVE-2023-30581"],
       windows:
-        Used Packages: Node 20.5.1 - Exe Format 
+        Used Packages: Node 20.5.1 - Exe Format
         CVE: ["CVE-2023-44487", "CVE-2023-39332", "CVE-2023-39331", "CVE-2023-38552"],
       ubuntu:
         Used Packages: Grafana 10.0.0 - .deb Format
@@ -406,16 +406,16 @@
             macos:
               amd64: node-v20.0.0
               arm64v8: node-v20.0.0
-    
+
 - case: Installation of a non vulnerable package
   id: install_package_non_vulnerable
   description: |
     Installation of a non vulnerable package
-      macos: 
+      macos:
         Used Packages: Node 19.5.0 - PKG Format
         CVE: [],
       windows:
-        Used Packages: Node 19.5.0 - Exe Format 
+        Used Packages: Node 19.5.0 - Exe Format
         CVE: [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -447,11 +447,11 @@
   id: remove_non_vulnerable_packge
   description: |
     Removal of a non vulnerable package
-      macos: 
+      macos:
         Used Packages: Node 19.5.0 - PKG Format
         CVE: [],
       windows:
-        Used Packages: Node 19.5.0 - Exe Format 
+        Used Packages: Node 19.5.0 - Exe Format
         CVE: [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -478,5 +478,3 @@
           macos:
             amd64: node-v19.6.0
             arm64v8: node-v19.6.0
-    
-

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -248,7 +248,7 @@ class TestInitialScans():
         else:
             logger.critical("All agents has been scanned")
 
-    def test_syscollector_first_scan_index(self, request, host_manager, setup_vulnerability_tests, get_results):
+    def test_vulnerability_first_scan_index(self, request, host_manager, setup_vulnerability_tests, get_results):
         """
         description: Validates that the Vulnerability Detector detects vulnerabilities within the environment in the
         first scan in the index.

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -15,13 +15,18 @@ Brief:
     The verification of vulnerabilities is conducted through Vulnerabilities Index and API endpoint
     Additionally, the tests ensure the consistency of these values.
 
-Tests: 
-    - TestInitialScans: Validates the initiation of Syscollector scans across all agents in the environment. 
-        - test_syscollector_first_scan: Validates the initiation of the first Syscollector scans across all agents in the environment.
-        - test_syscollector_first_scan_index: Validates that the Vulnerability Detector detects vulnerabilities within the environment in the first scan in the index.
-        - test_syscollector_second_scan: Validates the initiation of the second Syscollector scans across all agents in the environment.
-        - tests_syscollector_first_second_scan_consistency_index: Ensure the consistency of the agent's vulnerabilities between the first and second scans in index.
-    - TestScanSyscollectorCases: Validates the Vulnerability Detector's ability to detect new vulnerabilities in the environment.
+Tests:
+    - TestInitialScans: Validates the initiation of Syscollector scans across all agents in the environment.
+        - test_syscollector_first_scan: Validates the initiation of the first Syscollector scans across all agents in
+          the environment.
+        - test_syscollector_first_scan_index: Validates that the Vulnerability Detector detects vulnerabilities within
+          the environment in the first scan in the index.
+        - test_syscollector_second_scan: Validates the initiation of the second Syscollector scans across all agents in
+          the environment.
+        - tests_syscollector_first_second_scan_consistency_index: Ensure the consistency of the agent's vulnerabilities
+          between the first and second scans in index.
+    - TestScanSyscollectorCases: Validates the Vulnerability Detector's ability to detect new vulnerabilities in the
+      environment.
 
 Issue: https://github.com/wazuh/wazuh-qa/issues/4369
 
@@ -253,7 +258,6 @@ class TestInitialScans():
         else:
             logger.critical("All agents has been scanned")
 
-
     def test_syscollector_first_scan_index(self, request, host_manager, setup_vulnerability_tests, get_results):
         """
         description: Validates that the Vulnerability Detector detects vulnerabilities within the environment in the
@@ -341,7 +345,6 @@ class TestInitialScans():
         else:
             logger.critical("All agents has been scanned and updated states index")
 
-
     def test_syscollector_second_scan(self, request, host_manager, setup_vulnerability_tests, get_results):
         """
         description: Validates the initiation of the second Syscollector scans across all agents in the environment.
@@ -415,7 +418,6 @@ class TestInitialScans():
             pytest.fail(logging_message)
         else:
             logger.critical("Syscollector scan started in all agents")
-
 
     def tests_syscollector_first_second_scan_consistency_index(self, request, host_manager, setup_vulnerability_tests,
                                                                get_results):

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -58,7 +58,7 @@ from wazuh_testing.end_to_end.logs import truncate_remote_host_group_files
 from wazuh_testing.end_to_end.waiters import wait_until_vd_is_updated
 from wazuh_testing.end_to_end.monitoring import generate_monitoring_logs, monitoring_events_multihost
 from wazuh_testing.end_to_end.regex import get_event_regex
-from wazuh_testing.end_to_end.indexer_api import get_indexer_values
+from wazuh_testing.end_to_end.indexer_api import get_indexer_values, delete_index
 from wazuh_testing.tools.configuration import load_configuration_template
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.end_to_end.remote_operations_handler import launch_parallel_operations
@@ -140,13 +140,14 @@ def setup_vulnerability_tests(host_manager: HostManager) -> Generator:
     # Restart managers and stop agents
     logger.error("Stopping agents")
     host_manager.control_environment('stop', ['agent'])
-    logger.error("Restarting managers")
-    host_manager.control_environment('restart', ['manager'])
 
     utc_now_timestamp = datetime.datetime.now(datetime.timezone.utc)
 
     # Format the date and time as per the given format
     test_timestamp = utc_now_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    logger.error("Restarting managers")
+    host_manager.control_environment('restart', ['manager'])
 
     # Wait until VD is updated
     logger.error("Wait until Vulnerability Detector has update all the feeds")
@@ -160,6 +161,10 @@ def setup_vulnerability_tests(host_manager: HostManager) -> Generator:
     # Truncate alerts and logs of managers and agents
     logger.error("Truncate managers and agents logs")
     truncate_remote_host_group_files(host_manager, 'all', 'logs')
+
+    # Delete vulnerability index
+    logger.error("Delete vulnerability index")
+    delete_index(host_manager, index='wazuh-states-vulnerabilities')
 
     logger.error("Restoring original configuration")
     restore_configuration(host_manager, hosts_configuration_backup)

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -130,6 +130,8 @@ def setup_vulnerability_tests(host_manager: HostManager) -> Generator:
 
     logger.error("Configuring environment")
     configure_environment(host_manager, load_vulnerability_detector_configurations(host_manager))
+    logger.error("Save the Wazuh indexer username and password into the Wazuh manager keystore")
+    save_indexer_credentials_into_keystore(host_manager)
 
     # Truncate alerts and logs of managers and agents
     logger.error("Truncate managers and agents logs")
@@ -141,12 +143,6 @@ def setup_vulnerability_tests(host_manager: HostManager) -> Generator:
     logger.error("Restarting managers")
     host_manager.control_environment('restart', ['manager'])
 
-    logger.error("Save the Wazuh indexer username and password into the Wazuh manager keystore")
-    save_indexer_credentials_into_keystore(host_manager)
-
-    logger.error("Restarting managers")
-    host_manager.control_environment('restart', ['manager'])
-
     utc_now_timestamp = datetime.datetime.now(datetime.timezone.utc)
 
     # Format the date and time as per the given format
@@ -155,17 +151,6 @@ def setup_vulnerability_tests(host_manager: HostManager) -> Generator:
     # Wait until VD is updated
     logger.error("Wait until Vulnerability Detector has update all the feeds")
     wait_until_vd_is_updated(host_manager)
-
-    # Truncate alerts and logs of managers and agents
-    logger.error("Truncate managers and agents logs")
-    truncate_remote_host_group_files(host_manager, 'all', 'logs')
-
-    # Re-Register agents: https://github.com/wazuh/wazuh/issues/21185
-    logger.error("Removing agents")
-    host_manager.remove_agents()
-
-    # Wait until agents are registered again
-    time.sleep(15)
 
     # Start agents
     host_manager.control_environment('start', ['agent'])

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -142,7 +142,7 @@ def setup_vulnerability_tests(host_manager: HostManager) -> Generator:
     logger.error("Restarting managers")
     host_manager.control_environment('restart', ['manager'])
 
-    utc_now_timestamp = datetime.datetime.utcnow()
+    utc_now_timestamp = datetime.datetime.now(datetime.timezone.utc)
 
     # Format the date and time as per the given format
     test_timestamp = utc_now_timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -310,7 +310,10 @@ class TestInitialScans():
         time.sleep(TIMEOUT_PER_AGENT_VULNERABILITY_SCAN * len(agents_to_check))
 
         for agent in agents_to_check:
-            agent_all_vulnerabilities = get_indexer_values(host_manager, greater_than_timestamp=setup_vulnerability_tests, agent=agent, index='wazuh-states-vulnerabilities',)['hits']['hits']
+            agent_all_vulnerabilities = get_indexer_values(host_manager,
+                                                           greater_than_timestamp=setup_vulnerability_tests,
+                                                           agent=agent,
+                                                           index='wazuh-states-vulnerabilities',)['hits']['hits']
 
             vuln_by_agent_index[agent] = agent_all_vulnerabilities
 
@@ -464,30 +467,36 @@ class TestInitialScans():
         vuln_by_agent_index_second_scan = {}
         for agent in host_manager.get_group_hosts('agent'):
             agent_all_vulnerabilities = get_indexer_values(host_manager,
-                                                  greater_than_timestamp=setup_vulnerability_tests,
-                                                  index='wazuh-states-vulnerabilities',
-                                                  agent=agent)['hits']['hits']
+                                                           greater_than_timestamp=setup_vulnerability_tests,
+                                                           index='wazuh-states-vulnerabilities',
+                                                           agent=agent)['hits']['hits']
             # Only is expected alert of affected vulnerabilities
             vuln_by_agent_index_second_scan[agent] = agent_all_vulnerabilities
 
         test_result['evidences']['vulnerabilities_index_second_scan'] = vuln_by_agent_index_second_scan
 
         # Calculate differences between first and second scan
-        agent_not_found_in_first_scan = list(set(vuln_by_agent_index_second_scan.keys()) - set(results['vulnerabilities_index_first_scan'].keys()))
-        agent_not_found_in_second_scan = list(set(results['vulnerabilities_index_first_scan'].keys()) - set(vuln_by_agent_index_second_scan.keys()))
+        agent_not_found_in_first_scan = (list(set(vuln_by_agent_index_second_scan.keys()) -
+                                              set(results['vulnerabilities_index_first_scan'].keys())))
+        agent_not_found_in_second_scan = (list(set(results['vulnerabilities_index_first_scan'].keys()) -
+                                               set(vuln_by_agent_index_second_scan.keys())))
 
-        agent_found_in_all_scans = set(vuln_by_agent_index_second_scan.keys()) & set(results['vulnerabilities_index_first_scan'].keys())
+        agent_found_in_all_scans = (set(vuln_by_agent_index_second_scan.keys()) &
+                                    set(results['vulnerabilities_index_first_scan'].keys()))
 
         vulnerabilities_not_found_in_first_scan = {}
         vulnerabilities_not_found_in_second_scan = {}
 
         for agent in agent_found_in_all_scans:
             vulnerabilities_second_scan = get_vulnerabilities_from_states(vuln_by_agent_index_second_scan[agent])
-            vulnerabilities_first_scan = get_vulnerabilities_from_states(results['vulnerabilities_index_first_scan'][agent]) 
-            
+            vulnerabilities_first_scan = get_vulnerabilities_from_states(
+                                         results['vulnerabilities_index_first_scan'][agent])
+
             # Calculate differences between first and second scan
-            vulnerabilities_not_found_second_scan = list(set(vulnerabilities_first_scan) - set(vulnerabilities_second_scan))
-            vulnerabilities_not_found_first_scan = list(set(vulnerabilities_second_scan) - set(vulnerabilities_first_scan))
+            vulnerabilities_not_found_second_scan = (list(set(vulnerabilities_first_scan) -
+                                                          set(vulnerabilities_second_scan)))
+            vulnerabilities_not_found_first_scan = (list(set(vulnerabilities_second_scan) -
+                                                         set(vulnerabilities_first_scan)))
 
             # Change to dict to be able to serialize
             vulnerabilities_not_found_first_scan = [vuln._asdict() for vuln in vulnerabilities_not_found_first_scan]
@@ -498,8 +507,9 @@ class TestInitialScans():
             if len(vulnerabilities_not_found_first_scan) > 0:
                 vulnerabilities_not_found_in_first_scan[agent] = vulnerabilities_not_found_first_scan
 
-        # Check if agents are the same in both scans 
-        if len(agent_found_in_all_scans) != len(vuln_by_agent_index_second_scan) != len(results['vulnerabilities_index_first_scan']):
+        # Check if agents are the same in both scans
+        if (len(agent_found_in_all_scans) != len(vuln_by_agent_index_second_scan) !=
+                len(results['vulnerabilities_index_first_scan'])):
             test_result['checks']['all_successfull'] = False
             logging.critical("Inconsistencies found between first and second scan in the index. Different agents found")
             if len(agent_not_found_in_first_scan) > 0:
@@ -517,13 +527,15 @@ class TestInitialScans():
                 test_result['evidences']['vulnerabilities_not_found_in_first_scan'] = vulnerabilities_not_found_in_first_scan
 
             if vulnerabilities_not_found_in_second_scan:
-                logging.critical(f"Vulnerabilities not found in second scan: {vulnerabilities_not_found_in_second_scan}")
+                logging.critical("Vulnerabilities not found in second scan: "
+                                 f"{vulnerabilities_not_found_in_second_scan}")
                 test_result['evidences']['vulnerabilities_not_found_in_second_scan'] = vulnerabilities_not_found_in_second_scan
-    
+
         results[test_name] = test_result
 
         if not test_result['checks']['all_successfull']:
-            logging_message = "Inconsistencies found between first and second scan in the index. Check evidences for more information"
+            logging_message = "Inconsistencies found between first and second scan in the index." \
+                              "Check evidences for more information"
             logger.critical(logging_message)
             pytest.fail(logging_message)
 
@@ -555,8 +567,8 @@ class TestScanSyscollectorCases():
         return self.results
 
     @pytest.mark.parametrize('preconditions, body, teardown', complete_list, ids=list_ids)
-    def test_vulnerability_detector_scans_cases(self, setup_vulnerability_tests, request, preconditions, body, teardown, setup,
-                                                host_manager, get_results):
+    def test_vulnerability_detector_scans_cases(self, setup_vulnerability_tests, request, preconditions, body, teardown,
+                                                setup, host_manager, get_results):
         test_name = request.node.name
 
         setup_results = setup


### PR DESCRIPTION
|Related issue|
|:--:|
| #5108 |

## Description


- We have fixed a Grafana package wrong with the expected version.
- Added not to ignore timeout errors in waiters.
- Fixed a regex
- Removed extra steps in the setup

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->



| Validation | Jenkins | Local   | Commit | Notes                |
|--------------------|-----------|---------|--------|--------|
|    `end_to_end/test_vulnerability_detector`       | [🟡 ](https://ci.wazuh.info/view/Tests/job/Test_e2e_system/248/) | [🟡 ](https://github.com/wazuh/wazuh-qa/files/14836599/test_new.zip) |      225bb88         | Known issue: https://github.com/wazuh/wazuh-qa/issues/5173 and https://github.com/wazuh/wazuh-qa/issues/5175 |