### PR TITLE
Bug/5161 dtt1 iteration 3 allocation module fix inventory and track output path

### DIFF
--- a/deployability/modules/allocation/allocation.py
+++ b/deployability/modules/allocation/allocation.py
@@ -1,7 +1,6 @@
 import yaml
 
 from pathlib import Path
-import os
 
 from .aws.provider import AWSProvider, AWSConfig
 from .generic import Instance, Provider, models

--- a/deployability/modules/allocation/allocation.py
+++ b/deployability/modules/allocation/allocation.py
@@ -1,6 +1,7 @@
 import yaml
 
 from pathlib import Path
+import os
 
 from .aws.provider import AWSProvider, AWSConfig
 from .generic import Instance, Provider, models
@@ -107,7 +108,7 @@ class Allocator:
         """
         if inventory_path is None:
             inventory_path = Path(instance.path, 'inventory.yml')
-        else:
+        if not str(inventory_path).endswith('.yml') and not str(inventory_path).endswith('.yaml'):
             inventory_path = Path(inventory_path, 'inventory.yml')
         if not inventory_path.parent.exists():
             inventory_path.parent.mkdir(parents=True, exist_ok=True)
@@ -147,7 +148,7 @@ class Allocator:
         """
         if track_path is None:
             track_path = Path(instance.path, 'track.yml')
-        else:
+        if not str(track_path).endswith('.yml') and not str(track_path).endswith('.yaml'):
             track_path = Path(track_path, 'track.yml')
         if not track_path.parent.exists():
             track_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-qa/issues/5161

## Tests

### Test with custom file .yaml

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size large --ssh-key ~/.ssh/allocation_test --composite-name linux-ubuntu-22.04-amd64 --track-output /tmp/wazuh-qa/track-file-test.yaml --inventory-output /tmp/wazuh-qa/inventory-file-test.yaml
[2024-03-27 15:10:28] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-27 15:10:28] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-27 15:10:28] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-27 15:10:31] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-03-27 15:10:31] [INFO] ALLOCATOR: Instance VAGRANT-B11F4FB7-D9FA-4B37-8D8C-B458DF6DE97B created.
[2024-03-27 15:11:10] [INFO] ALLOCATOR: Instance VAGRANT-B11F4FB7-D9FA-4B37-8D8C-B458DF6DE97B started.
[2024-03-27 15:11:13] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/inventory-file-test.yaml
[2024-03-27 15:11:16] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/track-file-test.yaml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/inventory-file-test.yaml
ansible_connection: ssh
ansible_host: 192.168.57.5
ansible_port: 22
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/track-file-test.yaml
arch: amd64
host_identifier: None
host_instance_dir: None
identifier: VAGRANT-B11F4FB7-D9FA-4B37-8D8C-B458DF6DE97B
instance_dir: /tmp/wazuh-qa/VAGRANT-B11F4FB7-D9FA-4B37-8D8C-B458DF6DE97B
key_path: /home/cbordon/.ssh/allocation_test
platform: linux
provider: vagrant
ssh_port: 22
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --action delete --track-output /tmp/wazuh-qa/track-file-test.yaml
[2024-03-27 15:11:37] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/track-file-test.yaml
[2024-03-27 15:11:37] [DEBUG] ALLOCATOR: The key /home/cbordon/.ssh/allocation_test will not be deleted. It is the user's responsibility to delete it.
[2024-03-27 15:11:37] [DEBUG] ALLOCATOR: Destroying instance VAGRANT-B11F4FB7-D9FA-4B37-8D8C-B458DF6DE97B
[2024-03-27 15:11:43] [INFO] ALLOCATOR: Instance VAGRANT-B11F4FB7-D9FA-4B37-8D8C-B458DF6DE97B deleted.
```

### Test with custom file .yml

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size large --ssh-key ~/.ssh/allocation_test --composite-name linux-ubuntu-22.04-amd64 --track-output /tmp/wazuh-qa/track-file-test.yml --inventory-output /tmp/wazuh-qa/inventory-file-test.yml
[2024-03-27 15:11:51] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-27 15:11:51] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-27 15:11:51] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-27 15:11:54] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-03-27 15:11:54] [INFO] ALLOCATOR: Instance VAGRANT-F2F904DB-F903-467F-9FDF-2C76D22DA0D7 created.
[2024-03-27 15:12:34] [INFO] ALLOCATOR: Instance VAGRANT-F2F904DB-F903-467F-9FDF-2C76D22DA0D7 started.
[2024-03-27 15:12:37] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/inventory-file-test.yml
[2024-03-27 15:12:40] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/track-file-test.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/inventory-file-test.yml 
ansible_connection: ssh
ansible_host: 192.168.57.5
ansible_port: 22
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/track-file-test.yml
arch: amd64
host_identifier: None
host_instance_dir: None
identifier: VAGRANT-F2F904DB-F903-467F-9FDF-2C76D22DA0D7
instance_dir: /tmp/wazuh-qa/VAGRANT-F2F904DB-F903-467F-9FDF-2C76D22DA0D7
key_path: /home/cbordon/.ssh/allocation_test
platform: linux
provider: vagrant
ssh_port: 22
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test vagrant@192.168.57.5
The authenticity of host '192.168.57.5 (192.168.57.5)' can't be established.
ED25519 key fingerprint is SHA256:0BuMlSL7sy+SHbT+Vl8VMLWmfds80RIxZ4qCZvqH/og.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.57.5' (ED25519) to the list of known hosts.
Welcome to Ubuntu 22.04.3 LTS (GNU/Linux 5.15.0-92-generic x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/pro

  System information as of Wed Mar 27 18:12:22 UTC 2024

  System load:  0.16015625        Processes:               128
  Usage of /:   3.6% of 38.70GB   Users logged in:         0
  Memory usage: 2%                IPv4 address for enp0s3: 10.0.2.15
  Swap usage:   0%


Expanded Security Maintenance for Applications is not enabled.

0 updates can be applied immediately.

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status


The list of available updates is more than a week old.
To check for new updates run: sudo apt update

vagrant@ubuntu-jammy:~$ exit
logout
Connection to 192.168.57.5 closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --action delete --track-output /tmp/wazuh-qa/track-file-test.yml
[2024-03-27 15:13:53] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/track-file-test.yml
[2024-03-27 15:13:53] [DEBUG] ALLOCATOR: The key /home/cbordon/.ssh/allocation_test will not be deleted. It is the user's responsibility to delete it.
[2024-03-27 15:13:53] [DEBUG] ALLOCATOR: Destroying instance VAGRANT-F2F904DB-F903-467F-9FDF-2C76D22DA0D7
[2024-03-27 15:13:58] [INFO] ALLOCATOR: Instance VAGRANT-F2F904DB-F903-467F-9FDF-2C76D22DA0D7 deleted.
```

### Test with custom path

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size large --ssh-key ~/.ssh/allocation_test --composite-name linux-ubuntu-22.04-amd64 --track-output /tmp/wazuh-qa --inventory-output /tmp/wazuh-qa
[2024-03-27 15:15:58] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-27 15:15:58] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-27 15:15:58] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-27 15:16:01] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-03-27 15:16:01] [INFO] ALLOCATOR: Instance VAGRANT-203CB228-6E78-470E-B5F1-477E2C8E1B58 created.
[2024-03-27 15:16:41] [INFO] ALLOCATOR: Instance VAGRANT-203CB228-6E78-470E-B5F1-477E2C8E1B58 started.
[2024-03-27 15:16:44] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/inventory.yml
[2024-03-27 15:16:46] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/inventory.yml
ansible_connection: ssh
ansible_host: 192.168.57.5
ansible_port: 22
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/track.yml
arch: amd64
host_identifier: None
host_instance_dir: None
identifier: VAGRANT-203CB228-6E78-470E-B5F1-477E2C8E1B58
instance_dir: /tmp/wazuh-qa/VAGRANT-203CB228-6E78-470E-B5F1-477E2C8E1B58
key_path: /home/cbordon/.ssh/allocation_test
platform: linux
provider: vagrant
ssh_port: 22
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --action delete --track-output /tmp/wazuh-qa/track.yml
[2024-03-27 15:17:01] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/track.yml
[2024-03-27 15:17:01] [DEBUG] ALLOCATOR: The key /home/cbordon/.ssh/allocation_test will not be deleted. It is the user's responsibility to delete it.
[2024-03-27 15:17:01] [DEBUG] ALLOCATOR: Destroying instance VAGRANT-203CB228-6E78-470E-B5F1-477E2C8E1B58
[2024-03-27 15:17:06] [INFO] ALLOCATOR: Instance VAGRANT-203CB228-6E78-470E-B5F1-477E2C8E1B58 deleted.
```

### Test without arguments

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size large --ssh-key ~/.ssh/allocation_test --composite-name linux-ubuntu-22.04-amd64
[2024-03-27 15:14:10] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-03-27 15:14:10] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-03-27 15:14:10] [DEBUG] ALLOCATOR: Using provided key pair
[2024-03-27 15:14:13] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-03-27 15:14:13] [INFO] ALLOCATOR: Instance VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842 created.
[2024-03-27 15:14:52] [INFO] ALLOCATOR: Instance VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842 started.
[2024-03-27 15:14:55] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842/inventory.yml
[2024-03-27 15:14:58] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842/inventory.yml
ansible_connection: ssh
ansible_host: 192.168.57.5
ansible_port: 22
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842/track.yml
arch: amd64
host_identifier: None
host_instance_dir: None
identifier: VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842
instance_dir: /tmp/wazuh-qa/VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842
key_path: /home/cbordon/.ssh/allocation_test
platform: linux
provider: vagrant
ssh_port: 22
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --action delete --track-output /tmp/wazuh-qa/VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842/track.yml
[2024-03-27 15:15:13] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842/track.yml
[2024-03-27 15:15:13] [DEBUG] ALLOCATOR: The key /home/cbordon/.ssh/allocation_test will not be deleted. It is the user's responsibility to delete it.
[2024-03-27 15:15:13] [DEBUG] ALLOCATOR: Destroying instance VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842
[2024-03-27 15:15:18] [INFO] ALLOCATOR: Instance VAGRANT-A03E7662-F391-41E3-99D9-5C96D0B0E842 deleted.
```