### PR TITLE
Add fixture to modify the macOS agent timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix enrollment cluster system tests ([#5134](https://github.com/wazuh/wazuh-qa/pull/5134/)) \- (Tests)
+- Fix macOS and Windows agents timezone ([#5178](https://github.com/wazuh/wazuh-qa/pull/5178)) \- (Framework)
+- Fix enrollment cluster system tests ([#5134](https://github.com/wazuh/wazuh-qa/pull/5134)) \- (Tests)
 - Fix `test_synchronization` system test ([#5089](https://github.com/wazuh/wazuh-qa/pull/5089)) \- (Framework + Tests)
 - Fix number of files and their size for `test_zip_size_limit` ([#5133](https://github.com/wazuh/wazuh-qa/pull/5133)) \- (Tests)
 - Fix test_shutdown_message system test ([#5087](https://github.com/wazuh/wazuh-qa/pull/5087)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -362,7 +362,7 @@ class HostManager:
                                                   f'method={method} headers="{headers}" {request_body} '
                                                   f'validate_certs=no', check=check)
 
-    def run_command(self, host: str, cmd: str, check: bool = False):
+    def run_command(self, host: str, cmd: str, check: bool = False, system: str = 'linux'):
         """Run a command on the specified host and return its stdout.
 
         Args:
@@ -370,13 +370,18 @@ class HostManager:
             cmd (str): Command to execute
             check (bool, optional): Ansible check mode("Dry Run"), by default it is enabled so no changes will be
                 applied. Default `False`
+            system (str): The operating system type. Defaults to 'linux'.
+                Supported values: 'windows', 'macos', 'linux'.
 
         Returns:
             stdout (str): The output of the command execution.
         """
-        return self.get_host(host).ansible("command", cmd, check=check)["stdout"]
+        if system == 'windows':
+            return self.get_host(host).ansible("win_command", cmd, check=check)
+        else:
+            return self.get_host(host).ansible("command", cmd, check=check)["stdout"]
 
-    def run_shell(self, host: str, cmd: str, check: bool = False):
+    def run_shell(self, host: str, cmd: str, check: bool = False, system: str = 'linux'):
         """Run a shell command on the specified host and return its stdout.
 
         The difference with run_command is that here, shell symbols like &, |, etc. are interpreted.
@@ -386,11 +391,16 @@ class HostManager:
             cmd (str): Shell command to execute
             check (bool, optional): Ansible check mode("Dry Run"), by default it is enabled so no changes will be
                 applied. Default `False`
+            system (str): The operating system type. Defaults to 'linux'.
+                Supported values: 'windows', 'macos', 'linux'.
 
         Returns:
             stdout (str): The output of the command execution.
         """
-        return self.get_host(host).ansible('shell', cmd, check=check)['stdout']
+        if system == 'windows':
+            return self.get_host(host).ansible("win_shell", cmd, check=check)
+        else:
+            return self.get_host(host).ansible('shell', cmd, check=check)['stdout']
 
     def get_host_ip(self, host: str, interface: str):
         """Get the Ansible object for communicating with the specified host.

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -413,5 +413,7 @@ def modify_timezone(request):
             command = 'systemsetup -settimezone GMT'
         elif host_manager.get_host_variables(host)['os_name'] == 'windows':
             command = 'Set-TimeZone -Id "UTC"'
+        else:
+            continue
 
         host_manager.run_shell(host, command, system=host_manager.get_host_variables(host)['os_name'])

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -408,5 +408,9 @@ def modify_timezone(request):
     hosts = host_manager.get_group_hosts('agent')
 
     for host in hosts:
-        if host_manager.get_host_variables(host)['os'] and 'macos' in host_manager.get_host_variables(host)['os']:
-            host_manager.run_command(host, 'systemsetup -settimezone GMT')
+        if host_manager.get_host_variables(host)['os_name'] == 'macos':
+            command = 'systemsetup -settimezone GMT'
+        elif host_manager.get_host_variables(host)['os_name'] == 'windows':
+            command = 'Set-TimeZone -Id "UTC"'
+
+        host_manager.run_shell(host, command, system=host_manager.get_host_variables(host)['os_name'])

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -406,6 +406,7 @@ def modify_timezone(request):
     inventory_path = request.config.getoption('--inventory-path')
     host_manager = HostManager(inventory_path)
     hosts = host_manager.get_group_hosts('agent')
+    command = ''
 
     for host in hosts:
         if host_manager.get_host_variables(host)['os_name'] == 'macos':

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -399,3 +399,14 @@ def pytest_html_results_summary(prefix, summary, postfix):
 def pytest_configure(config):
     if not config.option.css:
         config.option.css = [STYLE_PATH]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def modify_timezone(request):
+    inventory_path = request.config.getoption('--inventory-path')
+    host_manager = HostManager(inventory_path)
+    hosts = host_manager.get_group_hosts('agent')
+
+    for host in hosts:
+        if host_manager.get_host_variables(host)['os'] and 'macos' in host_manager.get_host_variables(host)['os']:
+            host_manager.run_command(host, 'systemsetup -settimezone GMT')


### PR DESCRIPTION
|Related issue|
|:--:|
| #5175 |

## Description

Added a fixture to modify the macOS agent timezone.

---

## Testing performed



| Validation | Jenkins | Local  | Commit | Notes                |
|--------------------|-----------|---------|----------|--------|
|     `tests/end_to_end/ -k test_syscollector_first_scan`      | ⚫ |[🟡 ](https://github.com/wazuh/wazuh-qa/files/14880711/test_timezone.zip) |         1623db4b24d4cbf3b276cfb1a40cf04763f801e2     | Nothing to highlight |