### PR TITLE
Fixed userData script for openSUSE 15

### DIFF
--- a/deployability/modules/allocation/aws/helpers/userData.sh
+++ b/deployability/modules/allocation/aws/helpers/userData.sh
@@ -128,7 +128,7 @@ if [ ! -r "/etc/os-release" ] || [ "$DIST_NAME" = "centos" ]; then
     fi
 fi
 
-if [ "$DIST_NAME" = "amzn" ] || [ "$DIST_NAME" = "sles" ]; then
+if [ "$DIST_NAME" = "amzn" ] || [ "$DIST_NAME" = "sles" ] || [ "$DIST_NAME" = "opensuse-leap" ]; then
     sudo sed -i "s/#Port\s22/Port ${SSH_PORT}/" /etc/ssh/sshd_config
     sudo systemctl restart sshd.service
 fi


### PR DESCRIPTION
close: https://github.com/wazuh/wazuh-qa/issues/5192

Changes are made to the userData script that changes the ssh port to 2200 so that it recognizes the openSUSE 15 system


Test:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --composite-name linux-opensuse-15-amd64 --provider aws --size micro --ssh-key ~/.ssh/allocation_test --label-termination-date 1d --label-team devops
[2024-04-09 14:08:45] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-04-09 14:08:45] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-04-09 14:08:45] [DEBUG] ALLOCATOR: Using provided key pair
[2024-04-09 14:08:46] [DEBUG] ALLOCATOR: Creating temp directory: /tmp/wazuh-qa/AWS-F06352A0-D228-4B75-B4DF-5AFD7F9DB519
[2024-04-09 14:09:35] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-F06352A0-D228-4B75-B4DF-5AFD7F9DB519 directory to /tmp/wazuh-qa/i-07085eb9086a09e9c
[2024-04-09 14:09:35] [INFO] ALLOCATOR: Instance i-07085eb9086a09e9c created.
[2024-04-09 14:09:36] [INFO] ALLOCATOR: Instance i-07085eb9086a09e9c started.
[2024-04-09 14:09:36] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/i-07085eb9086a09e9c/inventory.yml
[2024-04-09 14:09:36] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/i-07085eb9086a09e9c/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-07085eb9086a09e9c/inventory.yml
ansible_connection: ssh
ansible_host: ec2-3-85-201-113.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_private_key_file: /home/cbordon/.ssh/allocation_test
ansible_user: ec2-user
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test -p 2200 ec2-user@ec2-3-85-201-113.compute-1.amazonaws.com
ssh: connect to host ec2-3-85-201-113.compute-1.amazonaws.com port 2200: Connection refused
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/.ssh/allocation_test -p 2200 ec2-user@ec2-3-85-201-113.compute-1.amazonaws.com
The authenticity of host '[ec2-3-85-201-113.compute-1.amazonaws.com]:2200 ([3.85.201.113]:2200)' can't be established.
ED25519 key fingerprint is SHA256:qYKRMBOE7bFwAQMBDj47GDwZmlSN005CoTsjmf7lmdY.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-3-85-201-113.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
openSUSE Leap 15.5 x86_64 (64-bit)
Suggestions email to: Alessandro de Oliveira Faria (A.K.A. CABELO) cabelo@opensuse.org

As "root" use the:
- zypper command for package management
- yast command for configuration management

Have a lot of fun...
ec2-user@ip-172-31-20-1:~> cat /etc/*release
NAME="openSUSE Leap"
VERSION="15.5"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.5"
PRETTY_NAME="openSUSE Leap 15.5"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.5"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
LOGO="distributor-logo-Leap"
ec2-user@ip-172-31-20-1:~> exit
logout
Connection to ec2-3-85-201-113.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-07085eb9086a09e9c/track.yml
[2024-04-09 14:13:24] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-07085eb9086a09e9c/track.yml
[2024-04-09 14:14:28] [INFO] ALLOCATOR: Instance i-07085eb9086a09e9c deleted.
```