### PR TITLE
Replace os.getlogin for getpass.getuser

### DIFF
--- a/deployability/modules/testing/testing.py
+++ b/deployability/modules/testing/testing.py
@@ -3,7 +3,7 @@
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
 import json
-import os
+import getpass
 
 from modules.generic import Ansible, Inventory
 from modules.generic.utils import Utils
@@ -50,7 +50,7 @@ class Tester:
 
         # Set extra vars
         extra_vars['local_host_path'] = str(Path(__file__).parent.parent.parent)
-        extra_vars['current_user'] = os.getlogin()
+        extra_vars['current_user'] = getpass.getuser()
 
         logger.debug(f"Using extra vars: {extra_vars}")
 


### PR DESCRIPTION
# Description
Closes: #5203 

The `getpass.getuser` function is more reliable than the `os.getlogin` function, this PR replace the former function call to get the current user of the process.

