### PR TITLE
Fix packages in some VD upgrade cases

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
@@ -525,7 +525,7 @@
     "CVE": [],
     "urls": {
       "windows": {
-          "amd64": "https://nodejs.org/dist/v19.5.0/win-x86/node.exe"
+          "amd64": "https://nodejs.org/dist/v19.5.0/node-v19.5.0-x64.msi"
       }
     },
     "uninstall_name": "node*"
@@ -536,7 +536,7 @@
     "CVE": [],
     "urls": {
       "windows": {
-          "amd64": "https://nodejs.org/dist/v19.6.0/win-x86/node.exe"
+          "amd64": "https://nodejs.org/dist/v19.6.0/node-v19.6.0-x64.msi"
       }
     },
     "uninstall_name": "node*"

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -8,7 +8,7 @@
         amd64: ["CVE-2017-16014"],
         arm64v8: ["CVE-2017-16014"],
       windows:
-        Used Package: Node 17.0.1 - Exe Format
+        Used Package: Node 17.0.1 - .msi Format
         CVE: ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
         Used Packages: Grafana 8.5.5 - .deb Format
@@ -45,7 +45,7 @@
         CVES Expected to mitigate:
           ["CVE-2017-16014"],
       windows:
-        Used Package: Node 17.0.1 - Exe Format
+        Used Package: Node 17.0.1 - .msi Format
         CVES Expected to mitigate:
           ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
       ubuntu:
@@ -86,7 +86,7 @@
         amd64: ["CVE-2017-16014"],
         arm64v8: ["CVE-2017-16014"],
     windows:
-      Used Package: Node 17.1.0 - Exe Format
+      Used Package: Node 17.1.0 - .msi Format
       "CVE": ["CVE-2022-21824", "CVE-2022-0778", "CVE-2021-44533", "CVE-2021-44532", "CVE-2021-44531", "CVE-2021-4044"],
     ubuntu:
       Used Packages: Grafana 8.5.6 - .deb Format
@@ -131,8 +131,8 @@
             windows:
               amd64: node-v17.0.1
             macos:
-              amd64: http-proxy-0.5.10
-              arm64v8: http-proxy-0.5.10
+              amd64: http-proxy-0.5.9
+              arm64v8: http-proxy-0.5.9
           to:
             centos:
               amd64: grafana-8.5.6-1
@@ -154,7 +154,7 @@
       Used Package: systeminformation 5.0.0 - npm Format
       CVE:  ["CVE-2021-21388", "CVE-2021-21315", "CVE-2023-42810"],
     windows:
-      Used Package: Node 18.0.0 - Exe Format
+      Used Package: Node 18.0.0 - .msi Format
       "CVE": ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30589", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32223", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
       Used Packages: Grafana 9.1.1 - .deb Format
@@ -206,7 +206,7 @@
       Used Package: systeminformation 5.0.0 - npm Format
       "CVE": ["CVE-2021-21388", "CVE-2021-21315", "CVE-2023-42810"],
     windows:
-      Used Package: Node 18.1.0 - Exe Format
+      Used Package: Node 18.1.0 - .msi Format
       "CVE": ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
       Used Packages: Grafana 9.2.0 - .deb Format
@@ -256,7 +256,7 @@
       Used Package: http-proxy 0.7.0 - npm Format
       "CVE": [],
     windows:
-      Used Package: Node 19.5.0 - Exe Format
+      Used Package: Node 19.5.0 - .msi Format
       "CVE": [],
     ubuntu:
       Used Packages: Grafana 9.4.17 - .deb Format
@@ -306,7 +306,7 @@
         Used Package: http-proxy 0.7.2 - npm Format
         "CVE": [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format
+        Used Package: Node 19.6.0 - .msi Format
         "CVE": [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -368,7 +368,7 @@
         Used Package: luxon 3.0.0 - npm Format
         "CVE": ["CVE-2022-31129"],
       windows:
-        Used Package: Node 20.5.1 - Exe Format
+        Used Package: Node 20.5.1 - .msi Format
         "CVE": ["CVE-2023-44487", "CVE-2023-39332", "CVE-2023-39331", "CVE-2023-38552"],
       ubuntu:
         Used Packages: Grafana 10.0.0 - .deb Format
@@ -418,7 +418,7 @@
         Used Package: http-proxy 0.7.0 - npm Format
         "CVE": [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format
+        Used Package: Node 19.5.0 - .msi Format
         "CVE": [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -454,7 +454,7 @@
         Used Package: http-proxy 0.7.0 - npm Format
         "CVE": [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format
+        Used Package: Node 19.5.0 - .msi Format
         "CVE": [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format


### PR DESCRIPTION
## Description

Related issue: https://github.com/wazuh/wazuh-qa/issues/5208

This PR aims to replace the download links of some node packages in the `vuln_packages.json` file and change the description of the test cases in the `test_vulnerability.yaml` file.

## Testing performed

The configured download links work correctly

![image](https://github.com/wazuh/wazuh-qa/assets/101177239/4192fc75-3856-4d04-ba6a-8bdad9eff962)

![image](https://github.com/wazuh/wazuh-qa/assets/101177239/235fb819-5b5d-4b77-b1a4-ebf6496b1864)


