### PR TITLE
Add OS Info when Simulating Packages

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/agent_simulator.py
@@ -780,6 +780,7 @@ class GeneratorSyscollector:
         self.old_format = old_format
         self.agent_name = agent_name
         self.batch_size = batch_size
+        self.osinfo_batch_size = batch_size
         self.syscollector_tag = 'syscollector'
         self.syscollector_mq = 'd'
         self.current_id = 1
@@ -949,9 +950,17 @@ class GeneratorSyscollector:
          Returns:
             str: generated event with the desired format for syscollector
         """
+        if len(self.list_events) == 1 and self.list_events[0] == 'packages':
+            self.list_events.insert(0, 'osinfo')
+            self.osinfo_batch_size = 1
+
         if self.current_batch_events_size == 0:
             self.current_batch_events = (self.current_batch_events + 1) % len(self.list_events)
-            self.current_batch_events_size = self.batch_size
+
+            if self.list_events[self.current_batch_events] != 'osinfo':
+                self.current_batch_events_size = self.batch_size
+            else:
+                self.current_batch_events_size = self.osinfo_batch_size
 
         if self.list_events[self.current_batch_events] not in ['network', 'port', 'process'] \
                 or self.current_batch_events_size > 1 or not self.old_format:


### PR DESCRIPTION
# Description

When using `simulate-agents` to generate Syscollector packages, you have to also send the OS info. If it is not sent, vulnerabilities are not generated and errors such as

```console
wazuh-modulesd:vulnerability-scanner: WARNING: Discarded event: Empty response from Wazuh-DB
```

To avoid this, when package events (and only packages) are generated, an osinfo event is also added to send the necessary OS information.

## Testing Performed

| OS | Package Used | Version | Result |
| --- | --- | --- | --- |
| Ubuntu 22.04 | Manager | 4.8.0 | :green_circle: |

The tests have been passed locally. To test the changes you have to use the `simulate-agents` with the following command `simulate-agents -a xxx.xx.x.xx -n 1 -m syscollector -s 5 -t 12 -o debian10 -v 4.8.0  --debug
` and check that no errors appear and all expected messages are generated.