### PR TITLE
Tests start before feeds are updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Change in the wait until the VD feed is completed ([#5227](https://github.com/wazuh/wazuh-qa/pull/5227)) \- (Tests)
 - Changes macOS packages with new ones that generate vulnerabilities ([#5174](https://github.com/wazuh/wazuh-qa/pull/5174)) \- (Tests)
 - Refactor initial scan Vulnerability E2E tests ([#5081](https://github.com/wazuh/wazuh-qa/pull/5081)) \- (Framework + Tests)
 - Update Packages in TestScanSyscollectorCases ([#4997](https://github.com/wazuh/wazuh-qa/pull/4997)) \- (Framework + Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Change in the wait until the VD feed is completed ([#5227](https://github.com/wazuh/wazuh-qa/pull/5227)) \- (Tests)
+- Change Vulnerability Detection feed updated waiter ([#5227](https://github.com/wazuh/wazuh-qa/pull/5227)) \- (Tests)
 - Changes macOS packages with new ones that generate vulnerabilities ([#5174](https://github.com/wazuh/wazuh-qa/pull/5174)) \- (Tests)
 - Refactor initial scan Vulnerability E2E tests ([#5081](https://github.com/wazuh/wazuh-qa/pull/5081)) \- (Framework + Tests)
 - Update Packages in TestScanSyscollectorCases ([#4997](https://github.com/wazuh/wazuh-qa/pull/4997)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
@@ -57,7 +57,7 @@ def wait_until_vd_is_updated(host_manager: HostManager) -> None:
 
     # Check initial scanner log
     if any(scanner_started_message in result['found'] for result in initial_results.values()):
-        print("Vulnerability scanner has started. Waiting for feed update completion...")
+        logging.info("Vulnerability scanner has started. Waiting for feed update completion...")
         # Proceed to check feed initiated log
         initiated_monitoring_data = generate_monitoring_logs(
             host_manager, [feed_update_initiated_message],
@@ -66,7 +66,7 @@ def wait_until_vd_is_updated(host_manager: HostManager) -> None:
         initiated_results = monitoring_events_multihost(host_manager, initiated_monitoring_data)
 
         if any(feed_update_initiated_message in result['found'] for result in initiated_results.values()):
-            print("Feed update process initiated successfully. Waiting for feed update completion...")
+            logging.info("Feed update process initiated successfully. Waiting for feed update completion...")
             # Finally check completion log
             completion_monitoring_data = generate_monitoring_logs(
                 host_manager, [feed_update_complete_message],
@@ -74,13 +74,13 @@ def wait_until_vd_is_updated(host_manager: HostManager) -> None:
             )
             completion_results = monitoring_events_multihost(host_manager, completion_monitoring_data)
             if any(feed_update_complete_message in result['found'] for result in completion_results.values()):
-                print("Feed update process completed successfully")
+                logging.info("Feed update process completed successfully")
             else:
                 raise TimeoutError("Timeout waiting for the feed update process to complete")
         else:
-            print("Feed update initiated log not found, the feed has already been updated previously")
+            logging.info("Feed update initiated log not found, the feed has already been updated previously")
     else:
-        print("Scanner start log not found")
+        logging.info("Scanner start log not found")
 
 def wait_until_vuln_scan_agents_finished(host_manager: HostManager) -> None:
     """

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
@@ -31,7 +31,7 @@ from wazuh_testing.tools.system import HostManager
 from wazuh_testing.modules.syscollector import TIMEOUT_SYSCOLLECTOR_SHORT_SCAN
 
 
-VD_FEED_UPDATE_TIMEOUT = 600
+VD_FEED_UPDATE_TIMEOUT = 6000
 VD_INITIAL_SCAN_PER_AGENT_TIMEOUT = 15
 
 
@@ -43,7 +43,9 @@ def wait_until_vd_is_updated(host_manager: HostManager) -> None:
         host_manager (HostManager): Host manager instance to handle the environment.
     """
 
-    monitoring_data = generate_monitoring_logs(host_manager, ["INFO: Vulnerability scanner module started"],
+    feed_update_complete_message = ["INFO: Feed update process completed"]
+
+    monitoring_data = generate_monitoring_logs(host_manager, feed_update_complete_message,
                                                [VD_FEED_UPDATE_TIMEOUT], host_manager.get_group_hosts('manager'))
     monitoring_events_multihost(host_manager, monitoring_data, ignore_timeout_error=False)
 

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/waiters.py
@@ -31,9 +31,9 @@ from wazuh_testing.tools.system import HostManager
 from wazuh_testing.modules.syscollector import TIMEOUT_SYSCOLLECTOR_SHORT_SCAN
 
 
-VD_FEED_UPDATE_TIMEOUT = 6000
+VD_FEED_UPDATE_COMPLETED_TIMEOUT = 900
+VD_FEED_UPDATE_INITIATED_TIMEOUT = 60
 VD_INITIAL_SCAN_PER_AGENT_TIMEOUT = 15
-
 
 def wait_until_vd_is_updated(host_manager: HostManager) -> None:
     """
@@ -43,12 +43,44 @@ def wait_until_vd_is_updated(host_manager: HostManager) -> None:
         host_manager (HostManager): Host manager instance to handle the environment.
     """
 
-    feed_update_complete_message = ["INFO: Feed update process completed"]
+    # Logs to monitor
+    scanner_started_message = "INFO: Vulnerability scanner module started"
+    feed_update_initiated_message = "INFO: Initiating update feed process"
+    feed_update_complete_message = "INFO: Feed update process completed"
 
-    monitoring_data = generate_monitoring_logs(host_manager, feed_update_complete_message,
-                                               [VD_FEED_UPDATE_TIMEOUT], host_manager.get_group_hosts('manager'))
-    monitoring_events_multihost(host_manager, monitoring_data, ignore_timeout_error=False)
+    # Generate and monitor initial scanner log
+    initial_monitoring_data = generate_monitoring_logs(
+        host_manager, [scanner_started_message],
+        [VD_FEED_UPDATE_COMPLETED_TIMEOUT], host_manager.get_group_hosts('manager')
+    )
+    initial_results = monitoring_events_multihost(host_manager, initial_monitoring_data)
 
+    # Check initial scanner log
+    if any(scanner_started_message in result['found'] for result in initial_results.values()):
+        print("Vulnerability scanner has started. Waiting for feed update completion...")
+        # Proceed to check feed initiated log
+        initiated_monitoring_data = generate_monitoring_logs(
+            host_manager, [feed_update_initiated_message],
+            [VD_FEED_UPDATE_INITIATED_TIMEOUT], host_manager.get_group_hosts('manager')
+        )
+        initiated_results = monitoring_events_multihost(host_manager, initiated_monitoring_data)
+
+        if any(feed_update_initiated_message in result['found'] for result in initiated_results.values()):
+            print("Feed update process initiated successfully. Waiting for feed update completion...")
+            # Finally check completion log
+            completion_monitoring_data = generate_monitoring_logs(
+                host_manager, [feed_update_complete_message],
+                [VD_FEED_UPDATE_COMPLETED_TIMEOUT], host_manager.get_group_hosts('manager')
+            )
+            completion_results = monitoring_events_multihost(host_manager, completion_monitoring_data)
+            if any(feed_update_complete_message in result['found'] for result in completion_results.values()):
+                print("Feed update process completed successfully")
+            else:
+                raise TimeoutError("Timeout waiting for the feed update process to complete")
+        else:
+            print("Feed update initiated log not found, the feed has already been updated previously")
+    else:
+        print("Scanner start log not found")
 
 def wait_until_vuln_scan_agents_finished(host_manager: HostManager) -> None:
     """


### PR DESCRIPTION
|Related issue|
|-------------|
|    #5173         |

## Description

This PR changes the function that waits for the feed to finish. We achieve this by changing the log that tells us that the feed has finished and increasing the timeout.