### PR TITLE
Add vulnerabilities and change packages in some Windows upgrade cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix vulnerabilities and add new packages to Vulnerability Detector E2E tests ([#5234](https://github.com/wazuh/wazuh-qa/pull/5234)) \- (Tests)
 - Fix provision macOS endpoints with npm ([#5128](https://github.com/wazuh/wazuh-qa/pull/5158)) \- (Tests)
 - Fix timestamps alerts and logs filter ([#5157](https://github.com/wazuh/wazuh-qa/pull/5157)) \- (Framework + Tests)
 - Fix macOS and Windows agents timezone ([#5178](https://github.com/wazuh/wazuh-qa/pull/5178)) \- (Framework)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector_packages/vuln_packages.json
@@ -455,6 +455,8 @@
     "package_name": "node",
     "package_version": "18.0.0",
     "CVE": [
+      "CVE-2023-44487",
+      "CVE-2023-23936",
       "CVE-2023-38552",
       "CVE-2023-32559",
       "CVE-2023-32006",
@@ -490,6 +492,9 @@
     "package_name": "node",
     "package_version": "18.1.0",
     "CVE": [
+      "CVE-2023-44487",
+      "CVE-2023-23936",
+      "CVE-2023-30589",
       "CVE-2023-38552",
       "CVE-2023-32559",
       "CVE-2023-32006",
@@ -519,10 +524,36 @@
     },
     "uninstall_name": "node*"
   },
+  "node-v18.20.0": {
+    "package_name": "node",
+    "package_version": "18.20.0",
+    "CVE": [],
+    "urls": {
+      "windows": {
+          "amd64": "https://nodejs.org/dist/v18.20.0/node-v18.20.0-x64.msi"
+      }
+    },
+    "uninstall_name": "node*"
+  },
+  "node-v18.20.2": {
+    "package_name": "node",
+    "package_version": "18.20.2",
+    "CVE": [],
+    "urls": {
+      "windows": {
+          "amd64": "https://nodejs.org/dist/v18.20.2/node-v18.20.2-x64.msi"
+      }
+    },
+    "uninstall_name": "node*"
+  },
   "node-v19.5.0": {
     "package_name": "node",
     "package_version": "19.5.0",
-    "CVE": [],
+    "CVE": [
+      "CVE-2023-23936",
+      "CVE-2023-23920",
+      "CVE-2023-23918"
+    ],
     "urls": {
       "windows": {
           "amd64": "https://nodejs.org/dist/v19.5.0/win-x86/node.exe"
@@ -533,7 +564,11 @@
   "node-v19.6.0": {
     "package_name": "node",
     "package_version": "19.6.0",
-    "CVE": [],
+    "CVE": [
+      "CVE-2023-23936",
+      "CVE-2023-23920",
+      "CVE-2023-23918"
+    ],
     "urls": {
       "windows": {
           "amd64": "https://nodejs.org/dist/v19.6.0/win-x86/node.exe"

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -155,7 +155,7 @@
       CVE:  ["CVE-2021-21388", "CVE-2021-21315", "CVE-2023-42810"],
     windows:
       Used Package: Node 18.0.0 - Exe Format
-      "CVE": ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30589", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32223", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
+      "CVE": ["CVE-2023-44487", CVE-2023-23936", CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30589", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32223", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
       Used Packages: Grafana 9.1.1 - .deb Format
       CVE: ["CVE-2023-2183", "CVE-2023-1387", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-39229", "CVE-2022-39201", "CVE-2022-36062", "CVE-2022-35957", "CVE-2022-31130", "CVE-2022-31123", "CVE-2022-23552", "CVE-2022-23498"],
@@ -207,7 +207,7 @@
       "CVE": ["CVE-2021-21388", "CVE-2021-21315", "CVE-2023-42810"],
     windows:
       Used Package: Node 18.1.0 - Exe Format
-      "CVE": ["CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
+      "CVE": ["CVE-2023-44487, CVE-2023-23936, CVE-2023-30589, CVE-2023-38552", "CVE-2023-32559", "CVE-2023-32006", "CVE-2023-32002", "CVE-2023-30590", "CVE-2023-30588", "CVE-2023-30585", "CVE-2023-30581", "CVE-2023-23920", "CVE-2023-23919", "CVE-2023-23918", "CVE-2022-43548", "CVE-2022-35256", "CVE-2022-35255", "CVE-2022-32222", "CVE-2022-32215", "CVE-2022-32214", "CVE-2022-32213", "CVE-2022-32212", "CVE-2022-3786", "CVE-2022-3602"],
     ubuntu:
       Used Packages: Grafana 9.2.0 - .deb Format
       CVE: ["CVE-2023-3128", "CVE-2023-22462", "CVE-2023-2183", "CVE-2023-1410", "CVE-2023-1387", "CVE-2023-0594", "CVE-2023-0507", "CVE-2022-39328", "CVE-2022-39324", "CVE-2022-39307", "CVE-2022-39306", "CVE-2022-23552", "CVE-2022-23498"],
@@ -256,7 +256,7 @@
       Used Package: http-proxy 0.7.0 - npm Format
       "CVE": [],
     windows:
-      Used Package: Node 19.5.0 - Exe Format
+      Used Package: Node 18.20.0 - Exe Format
       "CVE": [],
     ubuntu:
       Used Packages: Grafana 9.4.17 - .deb Format
@@ -293,7 +293,7 @@
               arm64v8: grafana-9.4.17
               amd64: grafana-9.4.17
             windows:
-              amd64: node-v19.5.0
+              amd64: node-v18.20.0
             macos:
               amd64: http-proxy-0.7.0
               arm64v8: http-proxy-0.7.0
@@ -306,7 +306,7 @@
         Used Package: http-proxy 0.7.2 - npm Format
         "CVE": [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format
+        Used Package: Node 18.20.2 - Exe Format
         "CVE": [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -323,7 +323,7 @@
           state_index: true
         package:
           windows:
-            amd64: node-v19.5.0
+            amd64: node-v18.20.0
           macos:
             amd64: http-proxy-0.7.0
             arm64v8: http-proxy-0.7.0
@@ -343,7 +343,7 @@
               arm64v8: grafana-9.4.17
               amd64: grafana-9.4.17
             windows:
-              amd64: node-v19.5.0
+              amd64: node-v18.20.0
             macos:
               amd64: http-proxy-0.7.0
               arm64v8: http-proxy-0.7.0
@@ -355,7 +355,7 @@
               amd64: grafana-9.5.13
               arm64v8: grafana-9.5.13
             windows:
-              amd64: node-v19.6.0
+              amd64: node-v18.20.2
             macos:
               amd64: http-proxy-0.7.2
               arm64v8: http-proxy-0.7.2
@@ -393,7 +393,7 @@
               amd64: grafana-9.5.13
               arm64v8: grafana-9.5.13
             windows:
-              amd64: node-v19.6.0
+              amd64: node-v18.20.2
             macos:
               amd64: luxon-2.5.2
               arm64v8: luxon-2.5.2
@@ -418,7 +418,7 @@
         Used Package: http-proxy 0.7.0 - npm Format
         "CVE": [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format
+        Used Package: Node 18.20.0 - Exe Format
         "CVE": [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -442,7 +442,7 @@
             amd64: grafana-9.5.13
             arm64v8: grafana-9.5.13
           windows:
-            amd64: node-v19.5.0
+            amd64: node-v18.20.0
           macos:
             amd64: http-proxy-0.7.0
             arm64v8: http-proxy-0.7.0
@@ -454,7 +454,7 @@
         Used Package: http-proxy 0.7.0 - npm Format
         "CVE": [],
       windows:
-        Used Package: Node 19.5.0 - Exe Format
+        Used Package: Node 18.20.0 - Exe Format
         "CVE": [],
       ubuntu:
         Used Packages: Grafana 9.5.13 - .deb Format
@@ -477,7 +477,7 @@
             amd64: grafana-9.5.13
             arm64v8: grafana-9.5.13
           windows:
-            amd64: node-v19.5.0
+            amd64: node-v18.20.0
           macos:
             amd64: http-proxy-0.7.0
             arm64v8: http-proxy-0.7.0


### PR DESCRIPTION
## Description

This PR aims to add some vulnerabilities in the `vuln_packages.json` file that were not contemplated before and add some new packages not vulnerable in some Windows upgrade cases. The `test_vulnerability.yaml` file has also been modified to incorporate these changes.

## Testing performed

These changes have been tested locally by running only the cases that have been modified, that is, from the `upgrade_package_maintain_add_vulnerability0` case onwards. The tests have failed, but in the alert file, you can see the alerts corresponding to the vulnerabilities of each installed package, so the test performance is as expected. The errors are due to the tests failing to detect vulnerabilities because of a change in the index reported in https://github.com/wazuh/wazuh-qa/issues/5239. 

Report: [report.zip](https://github.com/wazuh/wazuh-qa/files/15012741/report.zip)

