### PR TITLE
Create `GeneratorVulnerabilityEvents` Class in Agent Simulator

### DIFF
--- a/deps/wazuh_testing/setup.py
+++ b/deps/wazuh_testing/setup.py
@@ -31,6 +31,7 @@ package_data_list = [
     'data/qactl_conf_validator_schema.json',
     'data/all_disabled_ossec.conf',
     'data/syscollector_parsed_packages.json',
+    'data/vulnerability_parsed_packages.json',
     'tools/migration_tool/delta_schema.json',
     'end_to_end/vulnerability_detector_packages/vuln_packages.json',
     'tools/migration_tool/CVE_JSON_5.0_bundled.json'

--- a/deps/wazuh_testing/wazuh_testing/data/vulnerability_parsed_packages.json
+++ b/deps/wazuh_testing/wazuh_testing/data/vulnerability_parsed_packages.json
@@ -1,0 +1,878 @@
+[
+    {
+        "vendor": "bsdi",
+        "product": "bsd_os",
+        "version": "3.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.0"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.1.5.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "1.2"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.0"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.0.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.0.5"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.5"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.6"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.6.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.7"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.1.7.1"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.2"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.3"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.4"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.5"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.6"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "2.2.8"
+    },
+    {
+        "vendor": "freebsd",
+        "product": "freebsd",
+        "version": "3.0"
+    },
+    {
+        "vendor": "openbsd",
+        "product": "openbsd",
+        "version": "2.3"
+    },
+    {
+        "vendor": "openbsd",
+        "product": "openbsd",
+        "version": "2.4"
+    },
+    {
+        "vendor": "bsdi",
+        "product": "bsd_os",
+        "version": "1.1"
+    },
+    {
+        "vendor": "caldera",
+        "product": "openlinux",
+        "version": "1.2"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "2.0"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "2.1"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "3.0.3"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "4.0"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "4.1"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "4.2"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "5.0"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "5.1"
+    },
+    {
+        "vendor": "tritreal",
+        "product": "ted_cde",
+        "version": "4.3"
+    },
+    {
+        "vendor": "hp",
+        "product": "hp-ux",
+        "version": "10.01"
+    },
+    {
+        "vendor": "hp",
+        "product": "hp-ux",
+        "version": "10.02"
+    },
+    {
+        "vendor": "hp",
+        "product": "hp-ux",
+        "version": "10.03"
+    },
+    {
+        "vendor": "hp",
+        "product": "hp-ux",
+        "version": "11.00"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.1"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.2"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.3"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.4"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.5"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.2"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.2.1"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.3"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.2"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.3"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.0"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.1"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.2"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.3"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.4"
+    },
+    {
+        "vendor": "sun",
+        "product": "solaris",
+        "version": "2.6"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "0"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "4.1.3"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.0"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.1"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.2"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.3"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.4"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.5"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.5.1"
+    },
+    {
+        "vendor": "hp",
+        "product": "dtmail",
+        "version": "0"
+    },
+    {
+        "vendor": "university_of_washington",
+        "product": "pine",
+        "version": "4.02"
+    },
+    {
+        "vendor": "sco",
+        "product": "unixware",
+        "version": "7.0"
+    },
+    {
+        "vendor": "netscape",
+        "product": "messaging_server",
+        "version": "3.55"
+    },
+    {
+        "vendor": "university_of_washington",
+        "product": "imap",
+        "version": "10.234"
+    },
+    {
+        "vendor": "qualcomm",
+        "product": "qpopper",
+        "version": "2.4"
+    },
+    {
+        "vendor": "c2net",
+        "product": "stonghold_web_server",
+        "version": "2.0.1"
+    },
+    {
+        "vendor": "c2net",
+        "product": "stonghold_web_server",
+        "version": "2.2"
+    },
+    {
+        "vendor": "c2net",
+        "product": "stonghold_web_server",
+        "version": "2.3"
+    },
+    {
+        "vendor": "hp",
+        "product": "open_market_secure_webserver",
+        "version": "2.1"
+    },
+    {
+        "vendor": "microsoft",
+        "product": "exchange_server",
+        "version": "5.5"
+    },
+    {
+        "vendor": "microsoft",
+        "product": "internet_information_server",
+        "version": "3.0"
+    },
+    {
+        "vendor": "microsoft",
+        "product": "internet_information_server",
+        "version": "4.0"
+    },
+    {
+        "vendor": "microsoft",
+        "product": "site_server",
+        "version": "3.0"
+    },
+    {
+        "vendor": "netscape",
+        "product": "certificate_server patch1",
+        "version": "1.0"
+    },
+    {
+        "vendor": "netscape",
+        "product": "collabra_server",
+        "version": "3.5.2"
+    },
+    {
+        "vendor": "netscape",
+        "product": "directory_server patch5",
+        "version": "1.3"
+    },
+    {
+        "vendor": "netscape",
+        "product": "directory_server",
+        "version": "3.12"
+    },
+    {
+        "vendor": "netscape",
+        "product": "directory_server patch1",
+        "version": "3.1"
+    },
+    {
+        "vendor": "netscape",
+        "product": "enterprise_server",
+        "version": "2.0"
+    },
+    {
+        "vendor": "netscape",
+        "product": "enterprise_server",
+        "version": "3.0.1b"
+    },
+    {
+        "vendor": "netscape",
+        "product": "enterprise_server",
+        "version": "3.5.1"
+    },
+    {
+        "vendor": "netscape",
+        "product": "fasttrack_server",
+        "version": "3.01b"
+    },
+    {
+        "vendor": "netscape",
+        "product": "messaging_server",
+        "version": "3.54"
+    },
+    {
+        "vendor": "netscape",
+        "product": "proxy_server",
+        "version": "3.5.1"
+    },
+    {
+        "vendor": "ssleay",
+        "product": "ssleay",
+        "version": "0.6.6"
+    },
+    {
+        "vendor": "ssleay",
+        "product": "ssleay",
+        "version": "0.8.1"
+    },
+    {
+        "vendor": "ssleay",
+        "product": "ssleay",
+        "version": "0.9"
+    },
+    {
+        "vendor": "hp",
+        "product": "hp-ux",
+        "version": "10.34"
+    },
+    {
+        "vendor": "hp",
+        "product": "hp-ux",
+        "version": "11.00"
+    },
+    {
+        "vendor": "sun",
+        "product": "solaris",
+        "version": "2.6"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.3"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.4"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.5"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.5.1"
+    },
+    {
+        "vendor": "data_general",
+        "product": "dg_ux",
+        "version": "5.4_3.0"
+    },
+    {
+        "vendor": "data_general",
+        "product": "dg_ux",
+        "version": "5.4_3.1"
+    },
+    {
+        "vendor": "data_general",
+        "product": "dg_ux",
+        "version": "5.4_4.1"
+    },
+    {
+        "vendor": "data_general",
+        "product": "dg_ux",
+        "version": "5.4_4.11"
+    },
+    {
+        "vendor": "isc",
+        "product": "bind",
+        "version": "4.9.6"
+    },
+    {
+        "vendor": "isc",
+        "product": "bind",
+        "version": "8.1"
+    },
+    {
+        "vendor": "isc",
+        "product": "bind",
+        "version": "8.1.1"
+    },
+    {
+        "vendor": "bsdi",
+        "product": "bsd_os",
+        "version": "2.0"
+    },
+    {
+        "vendor": "bsdi",
+        "product": "bsd_os",
+        "version": "2.0.1"
+    },
+    {
+        "vendor": "bsdi",
+        "product": "bsd_os",
+        "version": "2.1"
+    },
+    {
+        "vendor": "caldera",
+        "product": "openlinux",
+        "version": "1.0"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.1"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.2"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.3"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.4"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.1.5"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.2"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.2.1"
+    },
+    {
+        "vendor": "ibm",
+        "product": "aix",
+        "version": "4.3"
+    },
+    {
+        "vendor": "nec",
+        "product": "asl_ux_4800",
+        "version": "64"
+    },
+    {
+        "vendor": "netbsd",
+        "product": "netbsd",
+        "version": "1.0"
+    },
+    {
+        "vendor": "netbsd",
+        "product": "netbsd",
+        "version": "1.1"
+    },
+    {
+        "vendor": "netbsd",
+        "product": "netbsd",
+        "version": "1.2"
+    },
+    {
+        "vendor": "netbsd",
+        "product": "netbsd",
+        "version": "1.2.1"
+    },
+    {
+        "vendor": "netbsd",
+        "product": "netbsd",
+        "version": "1.3"
+    },
+    {
+        "vendor": "netbsd",
+        "product": "netbsd",
+        "version": "1.3.1"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "4.0"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "4.1"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "4.2"
+    },
+    {
+        "vendor": "redhat",
+        "product": "linux",
+        "version": "5.0"
+    },
+    {
+        "vendor": "sco",
+        "product": "open_desktop",
+        "version": "3.0"
+    },
+    {
+        "vendor": "sco",
+        "product": "open_desktop",
+        "version": "5.0"
+    },
+    {
+        "vendor": "sco",
+        "product": "unixware",
+        "version": "2.1"
+    },
+    {
+        "vendor": "sco",
+        "product": "unixware",
+        "version": "7.0"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "3.2"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "3.3"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "3.3.1"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "3.3.2"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "3.3.3"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.1"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.1t"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.2"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.3"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.4"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.4b"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.4t"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5_iop"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5_ipr"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5a"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5d"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5e"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5f"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5g"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "4.0.5h"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.0"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.0.1"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.1"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.1.1"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.2"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "5.3"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.0"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.1"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.2"
+    },
+    {
+        "vendor": "sgi",
+        "product": "irix",
+        "version": "6.3"
+    },
+    {
+        "vendor": "sun",
+        "product": "solaris ppc",
+        "version": "2.5.1"
+    },
+    {
+        "vendor": "sun",
+        "product": "solaris x86",
+        "version": "2.5"
+    },
+    {
+        "vendor": "sun",
+        "product": "solaris x86",
+        "version": "2.5.1"
+    },
+    {
+        "vendor": "sun",
+        "product": "solaris",
+        "version": "2.6"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "0"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.3"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.4"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.5"
+    },
+    {
+        "vendor": "sun",
+        "product": "sunos",
+        "version": "5.5.1"
+    }
+]
+

--- a/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/simulate_agents.py
@@ -108,7 +108,10 @@ def create_agent(args, custom_labels):
         'syscollector_frequency': args.syscollector_frequency,
         'syscollector_event_types': args.syscollector_event_types,
         'syscollector_legacy_messages': args.syscollector_legacy_messages,
-        'syscollector_packages_vuln_content': args.syscollector_packages_list_file
+        'syscollector_packages_vuln_content': args.syscollector_packages_list_file,
+        'vulnerability_legacy_messages': args.vulnerability_legacy_messages,
+        'vulnerability_batch_size': args.vulnerability_batch_size,
+        'vulnerability_packages_vuln_content': args.vulnerability_packages_list_file
     }
 
     agent = ag.Agent(**agent_args)
@@ -403,6 +406,28 @@ def main():
                             type=str, help='''File containing a list of packages to be sent by syscollector.
                             One package per line. Default is None.''', required=False, default=None,
                             dest='syscollector_packages_list_file')
+    
+    arg_parser.add_argument('--vulnerability-legacy-messages',
+                            help='Enable prior 4.2 agents syscollector format. Default is False.',
+                            required=False,
+                            action='store_true',
+                            default=False,
+                            dest='vulnerability_legacy_messages')
+    
+    arg_parser.add_argument('--vulnerability-batch-size',
+                            type=int,
+                            help='Number of vulnerabilities per agent',
+                            required=False,
+                            default=10,
+                            dest='vulnerability_batch_size')
+    
+    arg_parser.add_argument('--vulnerability-packages-list-file', 
+                            metavar='<vulnerability_packages_list_file>',
+                            type=str, 
+                            help='''File containing a list of packages to be sent by syscollector. One package per line. Default is None.''', 
+                            required=False, 
+                            default=None,
+                            dest='vulnerability_packages_list_file')
 
     args = arg_parser.parse_args()
 


### PR DESCRIPTION
# Description

When using the class to generate syscollector packages, no vulnerabilities are generated since the class is not intended for this use. It is possible to make vulnerabilities work by using the agent simulator parameters.

To avoid misusing the syscollector generator, the `GeneratorVulnerabilityEvents` class has been created. This class generates syscollector packets for the purpose of generating vulnerabilities.

Related to https://github.com/wazuh/wazuh-qa/issues/5222

## Testing Performed

| OS | Package Used | Version | Result |
| --- | --- | --- | --- |
| Ubuntu 22.04 | Manager | 4.8.0 | :black_circle: |

For testing, it is possible to use the agent simulator locally using the command `simulate-agents -a xxx.xx.x.xx -n 1 -m vulnerability -s 5 -t 12 -o debian10 -v 4.8.0 - -debug`. The logs corresponding to the vulnerabilities that the simulator generates using the new class should appear in the Wazuh manager.