### PR TITLE
Fix change greater than timestamp by detected_at in vulnerability index 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Update to replace timestamp filter with vulnerabilities detected_at field.([#5266](https://github.com/wazuh/wazuh-qa/pull/5266)) \- (Framework + Tests)
+- Replace timestamp filter with vulnerabilities detected_at field.([#5266](https://github.com/wazuh/wazuh-qa/pull/5266)) \- (Framework + Tests)
 - Changes macOS packages with new ones that generate vulnerabilities ([#5174](https://github.com/wazuh/wazuh-qa/pull/5174)) \- (Tests)
 - Refactor initial scan Vulnerability E2E tests ([#5081](https://github.com/wazuh/wazuh-qa/pull/5081)) \- (Framework + Tests)
 - Update Packages in TestScanSyscollectorCases ([#4997](https://github.com/wazuh/wazuh-qa/pull/4997)) \- (Framework + Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Update to replace timestamp filter with vulnerabilities detected_at field.([#5266](https://github.com/wazuh/wazuh-qa/pull/5266)) \- (Framework + Tests)
 - Changes macOS packages with new ones that generate vulnerabilities ([#5174](https://github.com/wazuh/wazuh-qa/pull/5174)) \- (Tests)
 - Refactor initial scan Vulnerability E2E tests ([#5081](https://github.com/wazuh/wazuh-qa/pull/5081)) \- (Framework + Tests)
 - Update Packages in TestScanSyscollectorCases ([#4997](https://github.com/wazuh/wazuh-qa/pull/4997)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -40,17 +40,13 @@ def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': '
     logging.info(f"Getting values from the Indexer API for index {index}")
 
     url = f"https://{host_manager.get_master_ip()}:9200/{index}/_search"
-    headers = {
-        'Content-Type': 'application/json',
-    }
 
     data = {}
+    param = {'size': size}
+    headers = {'Content-Type': 'application/json'}
+
     if filter:
         data['query'] = filter
-
-    param = {
-        'size': size,
-    }
 
     response = requests.get(url=url, params=param, verify=False,
                             auth=requests.auth.HTTPBasicAuth(credentials['user'], credentials['password']),

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -21,6 +21,28 @@ from wazuh_testing.tools.system import HostManager
 STATE_INDEX_NAME = 'wazuh-states-vulnerabilities'
 
 
+def create_vulnerability_states_indexer_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+    return _create_filter(target_agent, greater_than_timestamp, 'vulnerability.detected_at')
+
+
+def create_alerts_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+    return _create_filter(target_agent, greater_than_timestamp, '@timestamp')
+
+
+def _create_filter(target_agent: str, greater_than_timestamp: str, timestamp_field: str) -> dict:
+    filter = {
+        'bool': {
+            'must': []
+        }
+    }
+    if greater_than_timestamp:
+        filter['bool']['must'].append({'range': {timestamp_field: {'gte': greater_than_timestamp}}})
+    if target_agent:
+        filter['bool']['must'].append({'match': {'agent.name': target_agent}})
+
+    return filter
+
+
 def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': 'admin', 'password': 'changeme'},
                        index: str = 'wazuh-alerts*', filter: dict | None = None, size: int = 10000) -> Dict:
     """

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -18,7 +18,7 @@ from typing import Dict
 from wazuh_testing.tools.system import HostManager
 
 
-STATE_INDEX_NAME = 'wazuh-vulnerabilities-states'
+STATE_INDEX_NAME = 'wazuh-states-vulnerabilities'
 
 
 def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': 'admin', 'password': 'changeme'},
@@ -45,7 +45,8 @@ def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': '
     }
 
     data = {}
-    data['query'] = filter
+    if filter:
+        data['query'] = filter
 
     param = {
         'size': size,

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -31,8 +31,8 @@ def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': '
         credentials (Optional): A dictionary containing the Indexer credentials. Defaults to
                                  {'user': 'admin', 'password': 'changeme'}.
         index (Optional): The Indexer index name. Defaults to 'wazuh-alerts*'.
-        greater_than_timestamp (Optional): The timestamp to filter the results. Defaults to None.
-        agent (Optional): The agent name to filter the results. Defaults to ''.
+        filter (Optional): A dictionary containing the query filter. Defaults to None.
+        size (Optional): The number of results to retrieve. Defaults to 10000.
 
     Returns:
        Dict: A dictionary containing the values retrieved from the Indexer API.

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -22,14 +22,42 @@ STATE_INDEX_NAME = 'wazuh-states-vulnerabilities'
 
 
 def create_vulnerability_states_indexer_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+    """Create a filter for the Indexer API for the vulnerability state index.
+
+    Args:
+        target_agent: The target agent to filter on.
+        greater_than_timestamp: The timestamp to filter on.
+
+    Returns:
+        dict: A dictionary containing the filter.
+    """
     return _create_filter(target_agent, greater_than_timestamp, 'vulnerability.detected_at')
 
 
 def create_alerts_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+    """Create a filter for the Indexer API for the alerts index.
+
+    Args:
+        target_agent: The target agent to filter on.
+        greater_than_timestamp: The timestamp to filter on.
+
+    Returns:
+        dict: A dictionary containing the filter.
+    """
     return _create_filter(target_agent, greater_than_timestamp, '@timestamp')
 
 
 def _create_filter(target_agent: str, greater_than_timestamp: str, timestamp_field: str) -> dict:
+    """Create a filter for the Indexer API.
+
+    Args:
+        target_agent: The target agent to filter on.
+        greater_than_timestamp: The timestamp to filter on.
+        timestamp_field: The timestamp field to filter on.
+
+    Returns:
+        dict: A dictionary containing the filter.
+    """
     filter = {
         'bool': {
             'must': []

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -22,7 +22,7 @@ STATE_INDEX_NAME = 'wazuh-vulnerabilities-states'
 
 
 def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': 'admin', 'password': 'changeme'},
-                       index: str = 'wazuh-alerts*', greater_than_timestamp=None, agent: str = '') -> Dict:
+                       index: str = 'wazuh-alerts*', filter: dict | None = None, size: int = 10000) -> Dict:
     """
     Get values from the Wazuh Indexer API.
 
@@ -44,47 +44,11 @@ def get_indexer_values(host_manager: HostManager, credentials: dict = {'user': '
         'Content-Type': 'application/json',
     }
 
-    data = {
-        "query": {
-            "match_all": {}
-        }
-    }
-
-    if greater_than_timestamp and agent:
-        query = {
-                "bool": {
-                    "must": [
-                        {"range": {"@timestamp": {"gte": f"{greater_than_timestamp}"}}},
-                        {"match": {"agent.name": f"{agent}"}}
-                    ]
-                }
-        }
-
-        data['query'] = query
-    elif greater_than_timestamp:
-        query = {
-                "bool": {
-                    "must": [
-                        {"range": {"@timestamp": {"gte": f"{greater_than_timestamp}"}}}
-                    ]
-                }
-        }
-
-        data['query'] = query
-    elif agent:
-        query = {
-                "bool": {
-                    "must": [
-                        {"match": {"agent.name": f"{agent}"}}
-                    ]
-                }
-        }
-
-        data['query'] = query
+    data = {}
+    data['query'] = filter
 
     param = {
-        'pretty': 'true',
-        'size': 10000,
+        'size': size,
     }
 
     response = requests.get(url=url, params=param, verify=False,

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -21,7 +21,8 @@ from wazuh_testing.tools.system import HostManager
 STATE_INDEX_NAME = 'wazuh-states-vulnerabilities'
 
 
-def create_vulnerability_states_indexer_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+def create_vulnerability_states_indexer_filter(target_agent: str | None = None,
+                                               greater_than_timestamp: str | None = None) -> dict:
     """Create a filter for the Indexer API for the vulnerability state index.
 
     Args:
@@ -31,10 +32,17 @@ def create_vulnerability_states_indexer_filter(target_agent: str, greater_than_t
     Returns:
         dict: A dictionary containing the filter.
     """
-    return _create_filter(target_agent, greater_than_timestamp, 'vulnerability.detected_at')
+    timestamp_filter = None
+    if greater_than_timestamp:
+        timestamp_filter = {
+                'greater_than_timestamp': greater_than_timestamp,
+                'timestamp_name': 'vulnerability.detected_at'
+        }
+
+    return _create_filter(target_agent, timestamp_filter)
 
 
-def create_alerts_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+def create_alerts_filter(target_agent: str | None = None, greater_than_timestamp: str | None = None) -> dict:
     """Create a filter for the Indexer API for the alerts index.
 
     Args:
@@ -44,10 +52,17 @@ def create_alerts_filter(target_agent: str, greater_than_timestamp: str) -> dict
     Returns:
         dict: A dictionary containing the filter.
     """
-    return _create_filter(target_agent, greater_than_timestamp, '@timestamp')
+    timestamp_filter = None
+    if greater_than_timestamp:
+        timestamp_filter = {
+                'greater_than_timestamp': greater_than_timestamp,
+                'timestamp_name': '@timestamp'
+        }
+
+    return _create_filter(target_agent, timestamp_filter)
 
 
-def _create_filter(target_agent: str, greater_than_timestamp: str, timestamp_field: str) -> dict:
+def _create_filter(target_agent: str | None = None, timestamp_filter: dict | None = None) -> dict:
     """Create a filter for the Indexer API.
 
     Args:
@@ -63,7 +78,9 @@ def _create_filter(target_agent: str, greater_than_timestamp: str, timestamp_fie
             'must': []
         }
     }
-    if greater_than_timestamp:
+    if timestamp_filter:
+        timestamp_field = timestamp_filter['timestamp_name']
+        greater_than_timestamp = timestamp_filter['greater_than_timestamp']
         filter['bool']['must'].append({'range': {timestamp_field: {'gte': greater_than_timestamp}}})
     if target_agent:
         filter['bool']['must'].append({'match': {'agent.name': target_agent}})

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
@@ -28,8 +28,9 @@ from concurrent.futures import ThreadPoolExecutor
 from wazuh_testing.end_to_end.waiters import wait_syscollector_and_vuln_scan
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.end_to_end.vulnerability_detector import check_vuln_alert_indexer, check_vuln_state_index, \
-        load_packages_metadata, parse_vulnerability_detector_alerts, create_vulnerability_states_indexer_filter, create_alerts_filter
-from wazuh_testing.end_to_end.indexer_api import get_indexer_values
+        load_packages_metadata, parse_vulnerability_detector_alerts
+from wazuh_testing.end_to_end.indexer_api import get_indexer_values, \
+        create_vulnerability_states_indexer_filter, create_alerts_filter
 
 
 def check_vulnerability_alerts(results: Dict, check_data: Dict, current_datetime: str, host_manager: HostManager,
@@ -46,7 +47,8 @@ def check_vulnerability_alerts(results: Dict, check_data: Dict, current_datetime
         alerts_filter = create_alerts_filter(agent, current_datetime)
         index_vuln_filter = create_vulnerability_states_indexer_filter(agent, current_datetime)
 
-        agent_all_alerts = parse_vulnerability_detector_alerts(get_indexer_values(host_manager, filter=alerts_filter)['hits']['hits'])
+        agent_all_alerts = parse_vulnerability_detector_alerts(get_indexer_values(host_manager,
+                                                                                  filter=alerts_filter)['hits']['hits'])
         agent_all_vulnerabilities = get_indexer_values(host_manager, filter=index_vuln_filter,
                                                        index='wazuh-states-vulnerabilities')['hits']['hits']
 

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
@@ -28,7 +28,7 @@ from concurrent.futures import ThreadPoolExecutor
 from wazuh_testing.end_to_end.waiters import wait_syscollector_and_vuln_scan
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.end_to_end.vulnerability_detector import check_vuln_alert_indexer, check_vuln_state_index, \
-        load_packages_metadata, parse_vulnerability_detector_alerts
+        load_packages_metadata, parse_vulnerability_detector_alerts, create_vulnerability_states_indexer_filter, create_alerts_filter
 from wazuh_testing.end_to_end.indexer_api import get_indexer_values
 
 
@@ -43,12 +43,11 @@ def check_vulnerability_alerts(results: Dict, check_data: Dict, current_datetime
     vulnerability_index = {}
 
     for agent in host_manager.get_group_hosts('agent'):
-        agent_all_alerts = parse_vulnerability_detector_alerts(get_indexer_values(host_manager,
-                                              greater_than_timestamp=current_datetime,
-                                              agent=agent)['hits']['hits'])
+        alerts_filter = create_alerts_filter(agent, current_datetime)
+        index_vuln_filter = create_vulnerability_states_indexer_filter(agent, current_datetime)
 
-        agent_all_vulnerabilities = get_indexer_values(host_manager, greater_than_timestamp=current_datetime,
-                                                       agent=agent,
+        agent_all_alerts = parse_vulnerability_detector_alerts(get_indexer_values(host_manager, filter=alerts_filter)['hits']['hits'])
+        agent_all_vulnerabilities = get_indexer_values(host_manager, filter=index_vuln_filter,
                                                        index='wazuh-states-vulnerabilities')['hits']['hits']
 
         vulnerability_alerts[agent] = agent_all_alerts['affected']

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
@@ -31,6 +31,28 @@ from collections import namedtuple
 Vulnerability = namedtuple('Vulnerability', ['cve', 'package_name', 'package_version', 'type', 'architecture'])
 
 
+def create_vulnerability_states_indexer_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+    return _create_filter(target_agent, greater_than_timestamp, 'vulnerability.detected_at')
+
+
+def create_alerts_filter(target_agent: str, greater_than_timestamp: str) -> dict:
+    return _create_filter(target_agent, greater_than_timestamp, '@timestamp')
+
+
+def _create_filter(target_agent: str, greater_than_timestamp: str, timestamp_field: str) -> dict:
+    filter = {
+        'bool': {
+            'must': []
+        }
+    }
+    if greater_than_timestamp:
+        filter['bool']['must'].append({'range': {timestamp_field: {'gte': greater_than_timestamp}}})
+    if target_agent:
+        filter['bool']['must'].append({'match': {'agent.name': target_agent}})
+
+    return filter
+
+
 def load_packages_metadata() -> Dict:
     """
     Load packages metadata from the packages.json file.
@@ -78,8 +100,8 @@ def check_vuln_state_index(host_manager: HostManager, host: str, package: Dict[s
         package (dict): Dictionary containing package data.
         current_datetime (str): Datetime to filter the vulnerability state index.
     """
-    index_vuln_state_content = get_indexer_values(host_manager, index='wazuh-states-vulnerabilities',
-                                                  greater_than_timestamp=current_datetime)['hits']['hits']
+    filter = create_vulnerability_states_indexer_filter(host, current_datetime)
+    index_vuln_state_content = get_indexer_values(host_manager, index='wazuh-states-vulnerabilities', filter=filter)['hits']['hits']
     expected_alerts_not_found = []
 
     logging.info(f"Checking vulnerability state index {package}")

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
@@ -23,34 +23,12 @@ import json
 from typing import Dict, List
 
 from wazuh_testing.tools.system import HostManager
-from wazuh_testing.end_to_end.indexer_api import get_indexer_values
+from wazuh_testing.end_to_end.indexer_api import get_indexer_values, create_vulnerability_states_indexer_filter
 from wazuh_testing.end_to_end.regex import REGEX_PATTERNS
 from collections import namedtuple
 
 
 Vulnerability = namedtuple('Vulnerability', ['cve', 'package_name', 'package_version', 'type', 'architecture'])
-
-
-def create_vulnerability_states_indexer_filter(target_agent: str, greater_than_timestamp: str) -> dict:
-    return _create_filter(target_agent, greater_than_timestamp, 'vulnerability.detected_at')
-
-
-def create_alerts_filter(target_agent: str, greater_than_timestamp: str) -> dict:
-    return _create_filter(target_agent, greater_than_timestamp, '@timestamp')
-
-
-def _create_filter(target_agent: str, greater_than_timestamp: str, timestamp_field: str) -> dict:
-    filter = {
-        'bool': {
-            'must': []
-        }
-    }
-    if greater_than_timestamp:
-        filter['bool']['must'].append({'range': {timestamp_field: {'gte': greater_than_timestamp}}})
-    if target_agent:
-        filter['bool']['must'].append({'match': {'agent.name': target_agent}})
-
-    return filter
 
 
 def load_packages_metadata() -> Dict:
@@ -101,7 +79,9 @@ def check_vuln_state_index(host_manager: HostManager, host: str, package: Dict[s
         current_datetime (str): Datetime to filter the vulnerability state index.
     """
     filter = create_vulnerability_states_indexer_filter(host, current_datetime)
-    index_vuln_state_content = get_indexer_values(host_manager, index='wazuh-states-vulnerabilities', filter=filter)['hits']['hits']
+    index_vuln_state_content = get_indexer_values(host_manager,
+                                                  index='wazuh-states-vulnerabilities',
+                                                  filter=filter)['hits']['hits']
     expected_alerts_not_found = []
 
     logging.info(f"Checking vulnerability state index {package}")

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -53,12 +53,12 @@ from wazuh_testing.end_to_end.logs import truncate_remote_host_group_files
 from wazuh_testing.end_to_end.waiters import wait_until_vd_is_updated
 from wazuh_testing.end_to_end.monitoring import generate_monitoring_logs, monitoring_events_multihost
 from wazuh_testing.end_to_end.regex import get_event_regex
-from wazuh_testing.end_to_end.indexer_api import get_indexer_values, delete_index
+from wazuh_testing.end_to_end.indexer_api import get_indexer_values, delete_index, \
+        create_vulnerability_states_indexer_filter, create_alerts_filter
 from wazuh_testing.tools.configuration import load_configuration_template
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.end_to_end.remote_operations_handler import launch_parallel_operations
-from wazuh_testing.end_to_end.vulnerability_detector import get_vulnerabilities_from_states, \
-        create_vulnerability_states_indexer_filter, create_alerts_filter
+from wazuh_testing.end_to_end.vulnerability_detector import get_vulnerabilities_from_states
 from wazuh_testing.modules.syscollector import TIMEOUT_SYSCOLLECTOR_SCAN
 
 
@@ -333,9 +333,9 @@ class TestInitialScans():
         time.sleep(TIMEOUT_PER_AGENT_VULNERABILITY_SCAN * len(agents_to_check))
 
         for agent in agents_to_check:
-            agent_all_vulnerabilities = get_indexer_values(host_manager, 
-                                                           filter=create_vulnerability_states_indexer_filter(target_agent=agent, 
-                                                                                                             greater_than_timestamp=setup_vulnerability_tests),
+            filter = create_vulnerability_states_indexer_filter(agent, setup_vulnerability_tests)
+            agent_all_vulnerabilities = get_indexer_values(host_manager,
+                                                           filter=filter,
                                                            index='wazuh-states-vulnerabilities')['hits']['hits']
 
             vuln_by_agent_index[agent] = agent_all_vulnerabilities

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -57,7 +57,8 @@ from wazuh_testing.end_to_end.indexer_api import get_indexer_values, delete_inde
 from wazuh_testing.tools.configuration import load_configuration_template
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.end_to_end.remote_operations_handler import launch_parallel_operations
-from wazuh_testing.end_to_end.vulnerability_detector import get_vulnerabilities_from_states
+from wazuh_testing.end_to_end.vulnerability_detector import get_vulnerabilities_from_states, \
+        create_vulnerability_states_indexer_filter, create_alerts_filter
 from wazuh_testing.modules.syscollector import TIMEOUT_SYSCOLLECTOR_SCAN
 
 
@@ -332,10 +333,10 @@ class TestInitialScans():
         time.sleep(TIMEOUT_PER_AGENT_VULNERABILITY_SCAN * len(agents_to_check))
 
         for agent in agents_to_check:
-            agent_all_vulnerabilities = get_indexer_values(host_manager,
-                                                           greater_than_timestamp=setup_vulnerability_tests,
-                                                           agent=agent,
-                                                           index='wazuh-states-vulnerabilities',)['hits']['hits']
+            agent_all_vulnerabilities = get_indexer_values(host_manager, 
+                                                           filter=create_vulnerability_states_indexer_filter(target_agent=agent, 
+                                                                                                             greater_than_timestamp=setup_vulnerability_tests),
+                                                           index='wazuh-states-vulnerabilities')['hits']['hits']
 
             vuln_by_agent_index[agent] = agent_all_vulnerabilities
 
@@ -486,10 +487,11 @@ class TestInitialScans():
 
         vuln_by_agent_index_second_scan = {}
         for agent in host_manager.get_group_hosts('agent'):
+            filter = create_alerts_filter(target_agent=agent, greater_than_timestamp=setup_vulnerability_tests)
             agent_all_vulnerabilities = get_indexer_values(host_manager,
-                                                           greater_than_timestamp=setup_vulnerability_tests,
-                                                           index='wazuh-states-vulnerabilities',
-                                                           agent=agent)['hits']['hits']
+                                                           filter=filter,
+                                                           index='wazuh-states-vulnerabilities')['hits']['hits']
+
             # Only is expected alert of affected vulnerabilities
             vuln_by_agent_index_second_scan[agent] = agent_all_vulnerabilities
 

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -487,7 +487,8 @@ class TestInitialScans():
 
         vuln_by_agent_index_second_scan = {}
         for agent in host_manager.get_group_hosts('agent'):
-            filter = create_alerts_filter(target_agent=agent, greater_than_timestamp=setup_vulnerability_tests)
+            filter = create_vulnerability_states_indexer_filter(target_agent=agent,
+                                                                greater_than_timestamp=setup_vulnerability_tests)
             agent_all_vulnerabilities = get_indexer_values(host_manager,
                                                            filter=filter,
                                                            index='wazuh-states-vulnerabilities')['hits']['hits']


### PR DESCRIPTION
# Description

This PR updates the index API functions in order to use the `detected_by` field instead of the `timestamp` field. For alerts, it continues to utilize the same field for filtering by timestamp.


---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->
### Environment

```
manager1:
    roles: [manager, filebeat, indexer]
    os: ubuntu_22
    type: master

agent3:
    roles: [agent]
    os: ubuntu_22
    manager: manager1
```


### Testing

| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | :black_circle:  | [:green_circle: ](https://github.com/wazuh/wazuh-qa/files/15041125/R.zip)  |         |         | Nothing to highlight |



