### PR TITLE
Fix logger imports

### DIFF
--- a/deployability/modules/testing/testing.py
+++ b/deployability/modules/testing/testing.py
@@ -9,7 +9,7 @@ from modules.generic import Ansible, Inventory
 from modules.generic.utils import Utils
 from pathlib import Path
 from .models import InputPayload, ExtraVars
-from .utils import logger
+from modules.testing.utils import logger
 
 
 class Tester:

--- a/deployability/modules/testing/tests/helpers/agent.py
+++ b/deployability/modules/testing/tests/helpers/agent.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 from .constants import WAZUH_CONF, WAZUH_ROOT
 from .executor import Executor, WazuhAPI
 from .generic import HostInformation, CheckFiles
-from .logger.logger import logger
+from modules.testing.utils import logger
 
 class WazuhAgent:
 

--- a/deployability/modules/testing/tests/helpers/generic.py
+++ b/deployability/modules/testing/tests/helpers/generic.py
@@ -14,8 +14,8 @@ import yaml
 from pathlib import Path
 from .constants import WAZUH_CONTROL, CLIENT_KEYS
 from .executor import Executor
-from modules.generic.logger import logger
 from .utils import Utils
+from modules.testing.utils import logger
 
 
 class HostInformation:

--- a/deployability/modules/testing/tests/helpers/manager.py
+++ b/deployability/modules/testing/tests/helpers/manager.py
@@ -8,7 +8,7 @@ import socket
 from .constants import CLUSTER_CONTROL, AGENT_CONTROL, WAZUH_CONF, WAZUH_ROOT
 from .executor import Executor, WazuhAPI
 from .generic import HostInformation, CheckFiles
-from .logger.logger import logger
+from modules.testing.utils import logger
 from .utils import Utils
 
 

--- a/deployability/modules/testing/tests/helpers/utils.py
+++ b/deployability/modules/testing/tests/helpers/utils.py
@@ -8,7 +8,7 @@ import yaml
 import logging
 import time
 
-from .logger.logger import logger
+from modules.testing.utils import logger
 
 
 paramiko_logger = logging.getLogger("paramiko")

--- a/deployability/modules/testing/tests/test_agent/test_install.py
+++ b/deployability/modules/testing/tests/test_agent/test_install.py
@@ -8,7 +8,7 @@ import re
 from ..helpers.agent import WazuhAgent
 from ..helpers.constants import WAZUH_ROOT
 from ..helpers.generic import HostConfiguration, HostInformation, GeneralComponentActions
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 from ..helpers.manager import WazuhManager
 from ..helpers.utils import Utils
 

--- a/deployability/modules/testing/tests/test_agent/test_registration.py
+++ b/deployability/modules/testing/tests/test_agent/test_registration.py
@@ -8,7 +8,7 @@ import re
 from ..helpers.agent import WazuhAgent, WazuhAPI
 from ..helpers.generic import HostInformation, GeneralComponentActions, Waits
 from ..helpers.manager import WazuhManager, WazuhAPI
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 from ..helpers.utils import Utils
 
 @pytest.fixture(scope="module", autouse=True)

--- a/deployability/modules/testing/tests/test_agent/test_restart.py
+++ b/deployability/modules/testing/tests/test_agent/test_restart.py
@@ -6,7 +6,7 @@ import pytest
 import re
 
 from ..helpers.generic import GeneralComponentActions, HostInformation
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 from ..helpers.manager import WazuhManager
 from ..helpers.utils import Utils
 

--- a/deployability/modules/testing/tests/test_agent/test_stop.py
+++ b/deployability/modules/testing/tests/test_agent/test_stop.py
@@ -7,7 +7,7 @@ import re
 
 from ..helpers.agent import WazuhAgent, WazuhAPI
 from ..helpers.generic import GeneralComponentActions, Waits, HostInformation
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 from ..helpers.utils import Utils
 
 @pytest.fixture(scope="module", autouse=True)

--- a/deployability/modules/testing/tests/test_agent/test_uninstall.py
+++ b/deployability/modules/testing/tests/test_agent/test_uninstall.py
@@ -9,7 +9,7 @@ from ..helpers.agent import WazuhAgent
 from ..helpers.constants import WAZUH_ROOT
 from ..helpers.generic import HostInformation, GeneralComponentActions, Waits
 from ..helpers.manager import WazuhManager, WazuhAPI
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 from ..helpers.utils import Utils
 
 @pytest.fixture(scope="module", autouse=True)

--- a/deployability/modules/testing/tests/test_manager/test_install.py
+++ b/deployability/modules/testing/tests/test_manager/test_install.py
@@ -8,7 +8,7 @@ from ..helpers.constants import WAZUH_ROOT
 from ..helpers.executor import WazuhAPI
 from ..helpers.generic import HostConfiguration, HostInformation, GeneralComponentActions
 from ..helpers.manager import WazuhManager
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 from ..helpers.utils import Utils
 
 

--- a/deployability/modules/testing/tests/test_manager/test_restart.py
+++ b/deployability/modules/testing/tests/test_manager/test_restart.py
@@ -5,7 +5,7 @@
 import pytest
 
 from ..helpers.generic import HostInformation, GeneralComponentActions
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/deployability/modules/testing/tests/test_manager/test_stop.py
+++ b/deployability/modules/testing/tests/test_manager/test_stop.py
@@ -5,7 +5,7 @@
 import pytest
 
 from ..helpers.generic import HostInformation, GeneralComponentActions
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/deployability/modules/testing/tests/test_manager/test_uninstall.py
+++ b/deployability/modules/testing/tests/test_manager/test_uninstall.py
@@ -7,7 +7,7 @@ import pytest
 from ..helpers.constants import WAZUH_ROOT
 from ..helpers.generic import HostInformation, GeneralComponentActions
 from ..helpers.manager import WazuhManager
-from modules.generic.logger import logger
+from modules.testing.utils import logger
 
 
 @pytest.fixture(scope="module", autouse=True)


### PR DESCRIPTION
# Description
Related issue: #5232 

This PR fixes the errors introduced by PR #5217. The testing module files now import the logger variable from `deployability/modules/testing/utils.py`.

I CREATED THIS PR TO MERGE fix/5232-fix-remaining-logger-imports INTO 4495-dtt1-release BECAUSE PR #5233 DID NOT APPLY THE COMMITS.