### PR TITLE
Added random assignment for IP address for Vagrant local deployment

### DIFF
--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -6,6 +6,7 @@ import os
 import platform, json
 import subprocess
 import boto3
+import random
 
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
@@ -244,8 +245,8 @@ class VagrantProvider(Provider):
             if response != 0:
                 return ip
 
-        for i in range(2, 254):
-            ip = f"192.168.57.{i}"
+        for i in range(254):
+            ip = f"192.168.57.{random.randint(2, 253)}"
             if check_ip(ip):
                 return ip
 


### PR DESCRIPTION
closes https://github.com/wazuh/wazuh-qa/issues/5237

A random assignment of the last octet of the IP is added for local deployments with Vagrant.

### Tests:

**3 threads**: https://github.com/wazuh/wazuh-qa/issues/5237#issuecomment-2073242440

**5 threads**: https://github.com/wazuh/wazuh-qa/issues/5237#issuecomment-2073283960