### PR TITLE
Removing python3-pip from remote_requirements.txt in deps

### DIFF
--- a/deployability/deps/remote_requirements.txt
+++ b/deployability/deps/remote_requirements.txt
@@ -1,4 +1,3 @@
-python3-pip
 pytest>=7.4.2,<8.0.0
 chardet==5.2.0
 pytest-tinybird==0.2.0


### PR DESCRIPTION
Removing python3-pip from remote_requirements.txt in deps