### PR TITLE
Storage is added according to the size of the AWS instance

### DIFF
--- a/deployability/modules/allocation/aws/models.py
+++ b/deployability/modules/allocation/aws/models.py
@@ -11,6 +11,7 @@ class AWSConfig(ProviderConfig):
     user: str
     key_name: str
     type: str
+    storage: int
     security_groups: list[str]
     termination_date: str
     issue: str | None = None

--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -197,6 +197,7 @@ class AWSProvider(Provider):
             with open(windosUserData_file, 'r') as file:
                 userData = file.read()
                 userData = userData.replace('ChangeMe', config.key_name)
+            config.storage = 60
         else:
             with open(userData_file, 'r') as file:
                 userData = file.read()
@@ -204,6 +205,17 @@ class AWSProvider(Provider):
             'ImageId': config.ami,
             'InstanceType': config.type,
             'SecurityGroupIds': config.security_groups,
+            'BlockDeviceMappings': [
+                {
+                    'DeviceName': '/dev/sda1',
+                    'Ebs': {
+
+                        'DeleteOnTermination': True,
+                        'VolumeSize': config.storage,
+                        'VolumeType': 'gp2'
+                    },
+                },
+            ],
             'MinCount': 1,
             'MaxCount': 1,
             'UserData': userData,
@@ -262,12 +274,15 @@ class AWSProvider(Provider):
             os_specs['zone'] = os_specs['zone'] + 'c'
             if arch == 'arm64':
                 config['type'] = 'mac2.metal'
+                config['storage'] = 100
             if arch == 'amd64':
                 config['type'] = 'mac1.metal'
+                config['storage'] = 100
         else:
             for spec in size_specs:
                 if fnmatch.fnmatch(arch, spec):
                     config['type'] = size_specs[spec]['type']
+                    config['storage'] = int(size_specs[spec]['storage'])
                     break
 
         config['ami'] = os_specs['ami']

--- a/deployability/modules/allocation/static/specs/size.yml
+++ b/deployability/modules/allocation/static/specs/size.yml
@@ -15,20 +15,28 @@ aws:
   micro:
     amd64:
       type: t2.small
+      storage: 20
     arm64:
       type: a1.medium
+      storage: 20
   small:
     amd64:
       type: t3.small
+      storage: 20
     arm64:
       type: a1.large
+      storage: 20
   medium:
     amd64:
       type: t3a.medium
+      storage: 20
     arm64:
       type: a1.xlarge
+      storage: 20
   large:
     amd64:
       type: c5ad.xlarge
+      storage: 30
     arm64:
       type: c6g.xlarge
+      storage: 30


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-qa/issues/5314

## Tests

### Size large

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider aws --size large --ssh-key ~/.ssh/allocation_test --label-team devops --label-termination-date "1d" --composite-name linux-ubuntu-22.04-amd64
[2024-04-30 06:55:09] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-04-30 06:55:09] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-04-30 06:55:09] [DEBUG] ALLOCATOR: Using provided key pair
[2024-04-30 06:55:10] [DEBUG] ALLOCATOR: Creating temp directory: /tmp/wazuh-qa/AWS-D1CD2D0E-EFF7-4E15-98A6-8CB5FD7E1D45
[2024-04-30 06:55:28] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-D1CD2D0E-EFF7-4E15-98A6-8CB5FD7E1D45 directory to /tmp/wazuh-qa/i-0979133a344a78e01
[2024-04-30 06:55:28] [INFO] ALLOCATOR: Instance i-0979133a344a78e01 created.
[2024-04-30 06:55:30] [INFO] ALLOCATOR: Instance i-0979133a344a78e01 started.
[2024-04-30 06:55:30] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/i-0979133a344a78e01/inventory.yml
[2024-04-30 06:55:30] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 44.212.0.237
[2024-04-30 06:56:01] [INFO] ALLOCATOR: SSH connection successful.
[2024-04-30 06:56:01] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/i-0979133a344a78e01/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-0979133a344a78e01/track.yml 
[2024-04-30 06:56:15] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-0979133a344a78e01/track.yml
[2024-04-30 06:57:03] [INFO] ALLOCATOR: Instance i-0979133a344a78e01 deleted.
```

![Screenshot_20240430_065600](https://github.com/wazuh/wazuh-qa/assets/64099752/8bc352cb-0ab0-4966-9b33-6d27603105d3)


## Size medium

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider aws --size medium --ssh-key ~/.ssh/allocation_test --label-team devops --label-termination-date "1d" --composite-name linux-ubuntu-22.04-amd64
[2024-04-30 07:11:06] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-04-30 07:11:06] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-04-30 07:11:06] [DEBUG] ALLOCATOR: Using provided key pair
[2024-04-30 07:11:07] [DEBUG] ALLOCATOR: Creating temp directory: /tmp/wazuh-qa/AWS-C59C60E8-25E7-413E-A7BE-C8FD3B5C271E
[2024-04-30 07:11:25] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-C59C60E8-25E7-413E-A7BE-C8FD3B5C271E directory to /tmp/wazuh-qa/i-06d2dc21bfa754010
[2024-04-30 07:11:25] [INFO] ALLOCATOR: Instance i-06d2dc21bfa754010 created.
[2024-04-30 07:11:26] [INFO] ALLOCATOR: Instance i-06d2dc21bfa754010 started.
[2024-04-30 07:11:27] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/i-06d2dc21bfa754010/inventory.yml
[2024-04-30 07:11:27] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 3.88.0.223
[2024-04-30 07:11:58] [INFO] ALLOCATOR: SSH connection successful.
[2024-04-30 07:11:58] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/i-06d2dc21bfa754010/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-06d2dc21bfa754010/track.yml 
[2024-04-30 07:12:23] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-06d2dc21bfa754010/track.yml
[2024-04-30 07:13:42] [INFO] ALLOCATOR: Instance i-06d2dc21bfa754010 deleted.
```

![Screenshot_20240430_071210](https://github.com/wazuh/wazuh-qa/assets/64099752/b211a568-510d-437a-acb4-a05b151b6a60)
