### PR TITLE
macOS sign box added to Allocation module

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -132,6 +132,9 @@ vagrant:
   macos-sonoma-14.0-arm64:
     box: macos-14
     box_version: 0.0.0
+  macos-ventura-sign-arm64:
+    box: macos-ventura-sign
+    box_version: 0.0.0
   # Windows
   windows-desktop-10-amd64:
     box: gusztavvargadr/windows-10


### PR DESCRIPTION
macOS sign box added

test:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size small --instance-name cbordon-test --composite-name macos-ventura-sign-arm64
[2024-05-02 15:37:01] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-05-02 15:37:01] [DEBUG] ALLOCATOR: Creating instance directory on remote host
[2024-05-02 15:37:06] [INFO] ALLOCATOR: macStadium server has less than 2 VMs running, deploying in this host.
[2024-05-02 15:37:10] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-02 15:37:10] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-02 15:37:14] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-05-02 15:37:18] [INFO] ALLOCATOR: Instance cbordon-test created.
[2024-05-02 15:38:19] [INFO] ALLOCATOR: Instance cbordon-test started.
[2024-05-02 15:38:37] [INFO] ALLOCATOR: Inventory file generated at /tmp/wazuh-qa/cbordon-test/inventory.yml
[2024-05-02 15:38:39] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-02 15:38:50] [INFO] ALLOCATOR: Track file generated at /tmp/wazuh-qa/cbordon-test/track.yml
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/cbordon-test/inventory.yml
ansible_connection: ssh
ansible_host: 10.10.0.250
ansible_password: vagrant
ansible_port: 43220
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -p 43220 vagrant@10.10.0.250
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ED25519 key sent by the remote host is
SHA256:c0uvKj8y2TdqgmNE0yFe3wwDc33CAUQXbtpr9jVzYy0.
Please contact your system administrator.
Add correct host key in /home/cbordon/.ssh/known_hosts to get rid of this message.
Offending ED25519 key in /home/cbordon/.ssh/known_hosts:1228
  remove with:
  ssh-keygen -f "/home/cbordon/.ssh/known_hosts" -R "[10.10.0.250]:43220"
Host key for [10.10.0.250]:43220 has changed and you have requested strict checking.
Host key verification failed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh-keygen -f "/home/cbordon/.ssh/known_hosts" -R "[10.10.0.250]:43220"
# Host [10.10.0.250]:43220 found: line 1228
/home/cbordon/.ssh/known_hosts updated.
Original contents retained as /home/cbordon/.ssh/known_hosts.old
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -p 43220 vagrant@10.10.0.250
The authenticity of host '[10.10.0.250]:43220 ([10.10.0.250]:43220)' can't be established.
ED25519 key fingerprint is SHA256:c0uvKj8y2TdqgmNE0yFe3wwDc33CAUQXbtpr9jVzYy0.
This host key is known by the following other names/addresses:
    ~/.ssh/known_hosts:1269: [hashed name]
    ~/.ssh/known_hosts:1281: [hashed name]
    ~/.ssh/known_hosts:1282: [hashed name]
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[10.10.0.250]:43220' (ED25519) to the list of known hosts.
(vagrant@10.10.0.250) Password:
Last login: Fri Apr 26 12:39:13 2024
vagrant@vagrants-Virtual-Machine ~ % sw_vers
ProductName:            macOS
ProductVersion:         13.5.2
BuildVersion:           22G91
vagrant@vagrants-Virtual-Machine ~ % exit
Connection to 10.10.0.250 closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/cbordon-test/track.yml
[2024-05-02 15:39:45] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/cbordon-test/track.yml
[2024-05-02 15:39:47] [DEBUG] ALLOCATOR: Destroying instance cbordon-test
[2024-05-02 15:40:07] [DEBUG] ALLOCATOR: Deleting remote directory /Users/jenkins/testing/cbordon-test
[2024-05-02 15:40:11] [DEBUG] ALLOCATOR: Killing remote process on port 43220
[2024-05-02 15:40:19] [INFO] ALLOCATOR: Instance cbordon-test deleted.
```