### PR TITLE
macOS fix upgrade case nonvulnerable to vulnerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix upgrade macOS package cases for vulnerability scanner E2E ([#5334](https://github.com/wazuh/wazuh-qa/pull/5334)) \- (Tests)  
 - Fix packages in Windows and macOS upgrade cases ([#5223](https://github.com/wazuh/wazuh-qa/pull/5223)) \- (Framework + Tests)
 - Fix vulnerabilities and add new packages to Vulnerability Detector E2E tests ([#5234](https://github.com/wazuh/wazuh-qa/pull/5234)) \- (Tests)
 - Fix provision macOS endpoints with npm ([#5128](https://github.com/wazuh/wazuh-qa/pull/5158)) \- (Tests)

--- a/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/cases/test_vulnerability.yaml
@@ -217,6 +217,12 @@
   id: upgrade_package_nonvulnerable_to_vulnerable
   description: |
     Upgrade to non vulnerable package to vulnerable
+  preconditions:
+    operation: install_package
+    package:
+      macos:
+        amd64: luxon-2.5.2
+        arm64v8: luxon-2.5.2
   body:
     operation: update_package
     package:


### PR DESCRIPTION
|Related issue|
|-------------|
|    #5312         |

## Description

This PR fixes the upgrade case ('upgrade_package_nonvulnerable_to_vulnerable') where the luxon package was not pre-installed.