### PR TITLE
List command dependencies on the README file

### DIFF
--- a/deployability/modules/allocation/README.MD
+++ b/deployability/modules/allocation/README.MD
@@ -11,7 +11,7 @@ Execution can be done from any operating system.
 
 Initially, you have to install the required Python libraries. We recommend using virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
-The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+To use this module, you should use a Debian-based system, we recommend using Ubuntu 22.04 for full compatibility, you must have installed at least Python 3.10.12 and pip3 22.0.2
 
 1. Activate the environment:
 

--- a/deployability/modules/allocation/README.MD
+++ b/deployability/modules/allocation/README.MD
@@ -11,6 +11,8 @@ Execution can be done from any operating system.
 
 Initially, you have to install the required Python libraries. We recommend using virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
+The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+
 1. Activate the environment:
 
   ```bash

--- a/deployability/modules/allocation/README.MD
+++ b/deployability/modules/allocation/README.MD
@@ -33,6 +33,17 @@ Initially, you have to install the required Python libraries. We recommend using
   pip3 install -r deployability/deps/requirements.txt
   ```
 
+4. The module may execute any of these commands:
+
+  - ssh
+  - ssh-keygen
+  - sshpass
+  - cat
+  - vagrant
+  - chmod
+  
+  These commands must be available to run on the Host Operating System.
+
 #### Use the Allocation module through the Workflow engine
 
 Now, it is possible to use the Worklow engine library to launch the provision module by doing the following steps:

--- a/deployability/modules/provision/README.MD
+++ b/deployability/modules/provision/README.MD
@@ -14,6 +14,8 @@ The execution of the workflow is done through the installation of its library.
 
 Initially, Python libraries must be installed. we recommended the use of virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
+The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+
 1. Create the python environment:
 
 	```bash

--- a/deployability/modules/provision/README.MD
+++ b/deployability/modules/provision/README.MD
@@ -14,7 +14,7 @@ The execution of the workflow is done through the installation of its library.
 
 Initially, Python libraries must be installed. we recommended the use of virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
-The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+To use this module, you should use a Debian-based system, we recommend using Ubuntu 22.04 for full compatibility, you must have installed at least Python 3.10.12 and pip3 22.0.2
 
 1. Create the python environment:
 

--- a/deployability/modules/testing/README.MD
+++ b/deployability/modules/testing/README.MD
@@ -55,9 +55,16 @@ Initially, Python libraries must be installed, we recommended the use of virtual
 	pip3 uninstall -y workflow_engine && pip3 install .
 	```
 
+6. The module may execute any of these commands:
+
+  - ssh
+  - scp
+  
+  These commands must be available to run on the Host Operating System.
+
   Run the module by doing the following steps:
 
-6. Test fixture to execute:
+7. Test fixture to execute:
 
       It will be necessary to create a fixture (YAML file) where the infrastructure, provisioning, and tests to be executed will be declared.
 

--- a/deployability/modules/testing/README.MD
+++ b/deployability/modules/testing/README.MD
@@ -17,6 +17,8 @@ The execution of the workflow is done through the installation of its library.
 
 Initially, Python libraries must be installed, we recommended the use of virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
+The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+
 1. Create the python environment:
 
 	```bash

--- a/deployability/modules/testing/README.MD
+++ b/deployability/modules/testing/README.MD
@@ -17,7 +17,7 @@ The execution of the workflow is done through the installation of its library.
 
 Initially, Python libraries must be installed, we recommended the use of virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
-The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+To use this module, you should use a Debian-based system, we recommend using Ubuntu 22.04 for full compatibility, you must have installed at least Python 3.10.12 and pip3 22.0.2
 
 1. Create the python environment:
 

--- a/deployability/modules/workflow_engine/README.MD
+++ b/deployability/modules/workflow_engine/README.MD
@@ -6,6 +6,8 @@ The execution of the Workflow is done through the installation of its library.
 
 Initially, Python libraries must be installed. It is recommended to use virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
+The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+
 1. Activate the environment:
 
 	```bash

--- a/deployability/modules/workflow_engine/README.MD
+++ b/deployability/modules/workflow_engine/README.MD
@@ -6,7 +6,7 @@ The execution of the Workflow is done through the installation of its library.
 
 Initially, Python libraries must be installed. It is recommended to use virtual environments. Follow the technical documentation at https://docs.python.org/3/library/venv.html.
 
-The Python version to use is 3.10.13 with pip3 version 22.0.2 or higher.
+To use this module, you should use a Debian-based system, we recommend using Ubuntu 22.04 for full compatibility, you must have installed at least Python 3.10.12 and pip3 22.0.2
 
 1. Activate the environment:
 


### PR DESCRIPTION
# Description

Related Issue: [#5323](https://github.com/wazuh/wazuh-qa/issues/5323)

This PR modifies the README files to list the commands that each module may execute and adds the Python and `pip3` versions used to develop and run the modules.