### PR TITLE
Remove sslverify from host manager install package method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Remove sslverify from host manager install package method ([#5339](https://github.com/wazuh/wazuh-qa/pull/5339)) \- (Framework)
 - Include additional Vulnerability Detector E2E tests ([#5287](https://github.com/wazuh/wazuh-qa/pull/5287)) \- (Framework + Tests)
 - Change Vulnerability Detection feed updated waiter ([#5227](https://github.com/wazuh/wazuh-qa/pull/5227)) \- (Tests)
 - Replace timestamp filter with vulnerabilities detected_at field.([#5266](https://github.com/wazuh/wazuh-qa/pull/5266)) \- (Framework + Tests)

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -505,7 +505,7 @@ class HostManager:
             result = self.get_host(host).ansible("apt", f"deb={url}", check=False)
         elif system == 'centos':
             result = self.get_host(host).ansible("yum", f"name={url} state=present "
-                                                'sslverify=false disable_gpg_check=True', check=False)
+                                                'disable_gpg_check=True', check=False)
         elif system == 'macos':
             package_name = url.split('/')[-1]
             result = self.get_host(host).ansible("command", f"curl -LO {url}", check=False)


### PR DESCRIPTION
# Description

This PR removed the sslverify option from the install package host manager method. This is not supported ansible-core less than 2.13.


| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | [:red_circle:](https://ci.wazuh.info/job/Test_e2e_system/279/)  | ⚫⚫ |         |         | Nothing to highlight |


> [!NOTE]
> The tests have failed, but it's important to note that this failure isn't linked to the recent fix that was implemented. Despite the test failure, both the installation and upgrade operations have been successful across all test cases.