### PR TITLE
Force instance name to be defined in vagrant deploy

### DIFF
--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -354,22 +354,3 @@ class AWSProvider(Provider):
                 logger.warning(f"{message}")
         else:
             logger.info(f"Dedicated host released: {host_identifier}")
-
-    @staticmethod
-    def generate_repository_name(repository: str) -> str:
-        """
-        Generate a repository name for the instance.
-
-        Args:
-            repository (str): Repository name.
-
-        Returns:
-            str: Repository name for the instance.
-        """
-        matches = re.findall(r'(\w+)', repository)
-        if len(matches) == 3:
-            return ''.join([c[0] for c in matches])
-        elif len(matches) == 2:
-            return matches[1]
-        else:
-            return repository

--- a/deployability/modules/allocation/generic/provider.py
+++ b/deployability/modules/allocation/generic/provider.py
@@ -5,6 +5,7 @@
 import shutil
 import uuid
 import yaml
+import re
 
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -202,3 +203,22 @@ class Provider(ABC):
         """
         with open(cls.MISC_PATH, "r") as f:
             return yaml.safe_load(f).get(cls.provider_name)
+
+    @staticmethod
+    def generate_repository_name(repository: str) -> str:
+        """
+        Generate a repository name for the instance.
+
+        Args:
+            repository (str): Repository name.
+
+        Returns:
+            str: Repository name for the instance.
+        """
+        matches = re.findall(r'(\w+)', repository)
+        if len(matches) == 3:
+            return ''.join([c[0] for c in matches])
+        elif len(matches) == 2:
+            return matches[1]
+        else:
+            return repository

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -83,7 +83,7 @@ class VagrantProvider(Provider):
             logger.debug(f"Checking if instance directory exists on remote host")
             cmd = f"ls {host_instance_dir} > /dev/null 2>&1"
             if VagrantUtils.remote_command(cmd, remote_host_parameters):
-                raise ValueError(f"Instance directory {host_instance_dir} already exists on remote host, Check if it is possible to delete the directory on the remote host.")
+                raise ValueError(f"Instance directory {host_instance_dir} already exists on remote host. Check if it is possible to delete the directory on the remote host.")
             logger.debug(f"Creating instance directory on remote host")
             cmd = f"mkdir {host_instance_dir}"
             VagrantUtils.remote_command(cmd, remote_host_parameters)

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -83,7 +83,7 @@ class VagrantProvider(Provider):
             logger.debug(f"Checking if instance directory exists on remote host")
             cmd = f"ls {host_instance_dir} > /dev/null 2>&1"
             if VagrantUtils.remote_command(cmd, remote_host_parameters):
-                raise ValueError(f"Instance directory {host_instance_dir} already exists on remote host, please delete it before creating a new instance.")
+                raise ValueError(f"Instance directory {host_instance_dir} already exists on remote host, Check if it is possible to delete the directory on the remote host.")
             logger.debug(f"Creating instance directory on remote host")
             cmd = f"mkdir {host_instance_dir}"
             VagrantUtils.remote_command(cmd, remote_host_parameters)

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -60,16 +60,15 @@ class VagrantProvider(Provider):
             raise ValueError("Instance name or issue label is required.")
 
         instance_id = name + "-" + str(random.randint(0000, 9999))
-
         # Create the instance directory.
-        instance_dir = base_dir / instance_id
-        try:
-            instance_dir.mkdir(parents=True)
-        except FileExistsError:
-            logger.debug(f"Instance directory {instance_dir} already exists. Assigning new suffix.")
-            instance_id = name + "-" + str(random.randint(0000, 9999))
-            instance_dir = base_dir / instance_id
-            instance_dir.mkdir(parents=True)
+        while True:
+            try:
+                instance_dir = base_dir / instance_id
+                instance_dir.mkdir(parents=True)
+                break
+            except FileExistsError:
+                logger.debug(f"Instance directory {instance_dir} already exists. Assigning new suffix.")
+                instance_id = name + "-" + str(random.randint(0000, 9999))
         platform = str(params.composite_name.split("-")[0])
         host_instance_dir = None
         host_identifier = None

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -59,14 +59,15 @@ class VagrantProvider(Provider):
         else:
             raise ValueError("Instance name or issue label is required.")
 
-        instance_id = name + "-" + str(random.randint(1000, 9999))
+        instance_id = name + "-" + str(random.randint(0000, 9999))
 
         # Create the instance directory.
         instance_dir = base_dir / instance_id
         try:
             instance_dir.mkdir(parents=True)
         except FileExistsError:
-            instance_id = name + "-" + str(random.randint(1000, 9999))
+            logger.debug(f"Instance directory {instance_dir} already exists. Assigning new suffix.")
+            instance_id = name + "-" + str(random.randint(0000, 9999))
             instance_dir = base_dir / instance_id
             instance_dir.mkdir(parents=True)
         platform = str(params.composite_name.split("-")[0])


### PR DESCRIPTION
Close https://github.com/wazuh/wazuh-qa/issues/5311

The PR aims to validate the configuration of an instance name in vagrant, either with the `--instance-name` or `--label-issue` parameter


Tests:

**Vagrant local:** https://github.com/wazuh/wazuh-qa/issues/5311#issuecomment-2096534037
**Issue format validation:** https://github.com/wazuh/wazuh-qa/issues/5311#issuecomment-2096536806
**AWS:** https://github.com/wazuh/wazuh-qa/issues/5311#issuecomment-2096546798
**Vagrant macOS ARM:** https://github.com/wazuh/wazuh-qa/issues/5311#issuecomment-2096577791
**Instance dir concurrency:** https://github.com/wazuh/wazuh-qa/issues/5311#issuecomment-2096606306
