### PR TITLE
Fix arm agent installation

### DIFF
--- a/deployability/modules/testing/tests/helpers/agent.py
+++ b/deployability/modules/testing/tests/helpers/agent.py
@@ -43,7 +43,7 @@ class WazuhAgent:
                 ])
             elif distribution == 'deb' and 'arm64' in architecture:
                 commands.extend([
-                    f"wget https://{s3_url}.wazuh.com/{release}/apt/pool/main/w/wazuh-agent/wazuh-agent_{wazuh_version}-1_arm64.deb && sudo WAZUH_MANAGER='MANAGER_IP' WAZUH_AGENT_NAME='{agent_name}' dpkg -i ./wazuh-agent_{wazuh_version}-1arm64.deb"
+                    f"wget https://{s3_url}.wazuh.com/{release}/apt/pool/main/w/wazuh-agent/wazuh-agent_{wazuh_version}-1_arm64.deb && sudo WAZUH_MANAGER='MANAGER_IP' WAZUH_AGENT_NAME='{agent_name}' dpkg -i ./wazuh-agent_{wazuh_version}-1_arm64.deb"
                 ])
             system_commands = [
                     "systemctl daemon-reload",


### PR DESCRIPTION
# Description

Related issue: #5352 

This PR fixes the installation failure of the Linux deb arm agent reported in the related issue.