### PR TITLE
Agents are not being restarted after manager change in E2E vulnerability detection tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Change manager Vulnerability Detector E2E test case ([#5345](https://github.com/wazuh/wazuh-qa/pull/5345)) \- (Tests)
 - Include additional Vulnerability Detector E2E tests ([#5287](https://github.com/wazuh/wazuh-qa/pull/5287)) \- (Framework + Tests)
 - Change Vulnerability Detection feed updated waiter ([#5227](https://github.com/wazuh/wazuh-qa/pull/5227)) \- (Tests)
 - Replace timestamp filter with vulnerabilities detected_at field.([#5266](https://github.com/wazuh/wazuh-qa/pull/5266)) \- (Framework + Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Change manager Vulnerability Detector E2E test case ([#5345](https://github.com/wazuh/wazuh-qa/pull/5345)) \- (Tests)
 - Include additional Vulnerability Detector E2E tests ([#5287](https://github.com/wazuh/wazuh-qa/pull/5287)) \- (Framework + Tests)
 - Change Vulnerability Detection feed updated waiter ([#5227](https://github.com/wazuh/wazuh-qa/pull/5227)) \- (Tests)
 - Replace timestamp filter with vulnerabilities detected_at field.([#5266](https://github.com/wazuh/wazuh-qa/pull/5266)) \- (Framework + Tests)
@@ -58,6 +57,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix truncate logs in change manager Vulnerability Detector E2E test case ([#5355](https://github.com/wazuh/wazuh-qa/pull/5355)) \- (Tests)
 - Fix packages in Windows and macOS upgrade cases ([#5223](https://github.com/wazuh/wazuh-qa/pull/5223)) \- (Framework + Tests)
 - Fix vulnerabilities and add new packages to Vulnerability Detector E2E tests ([#5234](https://github.com/wazuh/wazuh-qa/pull/5234)) \- (Tests)
 - Fix provision macOS endpoints with npm ([#5128](https://github.com/wazuh/wazuh-qa/pull/5158)) \- (Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix truncate logs in change manager Vulnerability Detector E2E test case ([#5355](https://github.com/wazuh/wazuh-qa/pull/5355)) \- (Tests)
+- Fix restart agent in change manager Vulnerability Detector E2E test case ([#5355](https://github.com/wazuh/wazuh-qa/pull/5355)) \- (Tests)
 - Fix shutdown messages system test ([#5298](https://github.com/wazuh/wazuh-qa/pull/5298)) \- (Framework + Tests)
 - Fix upgrade macOS package cases for vulnerability scanner E2E ([#5334](https://github.com/wazuh/wazuh-qa/pull/5334)) \- (Tests)
 - Fix test cases in Vulnerability Detection E2E test by adding new packages ([#5349](https://github.com/wazuh/wazuh-qa/pull/5349)) \- (Tests)

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -139,7 +139,7 @@ def clean_environment_logs(host_manager: HostManager, request):
     skip_truncate_tests = ['test_change_agent_manager']
 
     if any(test in request.node.name for test in skip_truncate_tests):
-        print("Skipping truncation of logs for this test.")
+        logging.error("Skipping truncation of logs for this test.")
     else:
         logging.error("Truncate managers and agents logs")
         truncate_remote_host_group_files(host_manager, "all", "logs")
@@ -159,7 +159,7 @@ def clean_environment_logs_function(host_manager: HostManager, request):
     skip_truncate_tests = ['test_change_agent_manager']
 
     if any(test in request.node.name for test in skip_truncate_tests):
-        print("Skipping truncation of logs for this test.")
+        logging.error("Skipping truncation of logs for this test.")
     else:
         logging.error("Truncate managers and agents logs")
         truncate_remote_host_group_files(host_manager, "all", "logs")

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -126,31 +126,43 @@ def backup_configuration(host_manager: HostManager):
 
 
 @pytest.fixture(scope="module")
-def clean_environment_logs(host_manager: HostManager):
+def clean_environment_logs(host_manager: HostManager, request):
     """Clean Agents and Managers logs
 
     Args:
         host_manager: An instance of the HostManager class containing information about hosts.
+        request: The request object to access the current test request data.
 
     """
     yield
 
-    logging.error("Truncate managers and agents logs")
-    truncate_remote_host_group_files(host_manager, "all", "logs")
+    skip_truncate_tests = ['test_change_agent_manager']
+
+    if any(test in request.node.name for test in skip_truncate_tests):
+        print("Skipping truncation of logs for this test.")
+    else:
+        logging.error("Truncate managers and agents logs")
+        truncate_remote_host_group_files(host_manager, "all", "logs")
 
 
 @pytest.fixture(scope="function")
-def clean_environment_logs_function(host_manager: HostManager):
+def clean_environment_logs_function(host_manager: HostManager, request):
     """Clean Agents and Managers logs
 
     Args:
         host_manager: An instance of the HostManager class containing information about hosts.
+        request: The request object to access the current test request data.
 
     """
     yield
 
-    logging.error("Truncate managers and agents logs")
-    truncate_remote_host_group_files(host_manager, "all", "logs")
+    skip_truncate_tests = ['test_change_agent_manager']
+
+    if any(test in request.node.name for test in skip_truncate_tests):
+        print("Skipping truncation of logs for this test.")
+    else:
+        logging.error("Truncate managers and agents logs")
+        truncate_remote_host_group_files(host_manager, "all", "logs")
 
 
 @pytest.fixture(scope="module")

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -126,43 +126,31 @@ def backup_configuration(host_manager: HostManager):
 
 
 @pytest.fixture(scope="module")
-def clean_environment_logs(host_manager: HostManager, request):
+def clean_environment_logs(host_manager: HostManager):
     """Clean Agents and Managers logs
 
     Args:
         host_manager: An instance of the HostManager class containing information about hosts.
-        request: The request object to access the current test request data.
 
     """
     yield
 
-    skip_truncate_tests = ['test_change_agent_manager']
-
-    if any(test in request.node.name for test in skip_truncate_tests):
-        logging.error("Skipping truncation of logs for this test.")
-    else:
-        logging.error("Truncate managers and agents logs")
-        truncate_remote_host_group_files(host_manager, "all", "logs")
+    logging.error("Truncate managers and agents logs")
+    truncate_remote_host_group_files(host_manager, "all", "logs")
 
 
 @pytest.fixture(scope="function")
-def clean_environment_logs_function(host_manager: HostManager, request):
+def clean_environment_logs_function(host_manager: HostManager):
     """Clean Agents and Managers logs
 
     Args:
         host_manager: An instance of the HostManager class containing information about hosts.
-        request: The request object to access the current test request data.
 
     """
     yield
 
-    skip_truncate_tests = ['test_change_agent_manager']
-
-    if any(test in request.node.name for test in skip_truncate_tests):
-        logging.error("Skipping truncation of logs for this test.")
-    else:
-        logging.error("Truncate managers and agents logs")
-        truncate_remote_host_group_files(host_manager, "all", "logs")
+    logging.error("Truncate managers and agents logs")
+    truncate_remote_host_group_files(host_manager, "all", "logs")
 
 
 @pytest.fixture(scope="module")

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -622,9 +622,18 @@ class TestScanSyscollectorCases:
             )
             change_agent_manager_ip(host_manager, agent, manager_ip)
 
+        # Restart agents to apply the new configuration changes
+        logging.error("Restarting agents")
+        host_manager.control_environment("restart", ["agent"], parallel=True)
+
         yield
 
+        # Restore the original configuration after tests are done
         restore_configuration(host_manager, backup_configuration)
+
+        # Restart agents again to ensure they reconnect with their original managers
+        logging.error("Restarting agents")
+        host_manager.control_environment("restart", ["agent"], parallel=True)
 
     @pytest.mark.parametrize("preconditions, body, teardown", single_vulnerable_case_complete_list,
                              ids=single_vulnerable_case_list_ids,)


### PR DESCRIPTION
|Related issue|
|-------------|
|    #5345         |

## Description

This PR fix the restart of the agents in  `test_change_agent_manager` case.