### PR TITLE
Add timestamp to indexer statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Add `Timestamp` field to the indexer statistics ([#5357](https://github.com/wazuh/wazuh-qa/pull/5357)) \- (Framework)
 - Add `GeneratorVulnerabilityEvents` in agent simulator ([#5265](https://github.com/wazuh/wazuh-qa/pull/5265)) \- (Framework)
 - Add functionality to obtain statistics and metrics from the indexer ([#5090](https://github.com/wazuh/wazuh-qa/pull/5090)) \- (Framework)
 - Add support for the installation/uninstallation of npm packages ([#5092](https://github.com/wazuh/wazuh-qa/pull/5092)) \- (Tests)

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/statistic.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/statistic.py
@@ -342,13 +342,15 @@ class StatisticMonitor:
                     ))
                 elif target == "vulnerabilities":
                     logger.info("Writing vulnerabilities data info to {}.".format(csv_file))
-                    log.write(("{0}\n").format(
-                        data
+                    log.write(("{0},{1}\n").format(
+                        data,
+                        timestamp
                     ))
                 elif target == "alerts":
                     logger.info("Writing alerts data info to {}.".format(csv_file))
-                    log.write(("{0}\n").format(
-                        data
+                    log.write(("{0},{1}\n").format(
+                        data,
+                        timestamp
                     ))
                 elif target == "remote":
                     metrics = data['metrics']

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/statistic.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/statistic.py
@@ -343,14 +343,14 @@ class StatisticMonitor:
                 elif target == "vulnerabilities":
                     logger.info("Writing vulnerabilities data info to {}.".format(csv_file))
                     log.write(("{0},{1}\n").format(
-                        data,
-                        timestamp
+                        timestamp,
+                        data
                     ))
                 elif target == "alerts":
                     logger.info("Writing alerts data info to {}.".format(csv_file))
                     log.write(("{0},{1}\n").format(
-                        data,
-                        timestamp
+                        timestamp,
+                        data
                     ))
                 elif target == "remote":
                     metrics = data['metrics']

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/statistic_headers.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/statistic_headers.py
@@ -165,11 +165,11 @@ agentd_header = ["Timestamp",
                  "Number of messages",
                  "Number of events buffered"]
 
-vulns_header = ["Total vulnerabilities",
-                "timestamp"]
+vulns_header = ["Timestamp",
+                "Total vulnerabilities"]
 
-alerts_header = ["Total alerts",
-                 "timestamp"]
+alerts_header = ["Timestamp",
+                 "Total alerts"]
 
 
 wazuhdb_header = ["Timestamp",

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/statistic_headers.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/statistic_headers.py
@@ -165,9 +165,11 @@ agentd_header = ["Timestamp",
                  "Number of messages",
                  "Number of events buffered"]
 
-vulns_header = ["Total vulnerabilities"]
+vulns_header = ["Total vulnerabilities",
+                "timestamp"]
 
-alerts_header = ["Total alerts"]
+alerts_header = ["Total alerts",
+                 "timestamp"]
 
 
 wazuhdb_header = ["Timestamp",


### PR DESCRIPTION
# Description

This PR aims to add the `timestamp` field to the indexer statistics, such as alerts and vulnerabilities since it is advisable to include this to streamline automation for plot generation.

## Testing performed

Build: https://ci.wazuh.info/job/CLUSTER-Workload_benchmarks_metrics/514/

Artifacts: [artifacts.zip](https://github.com/wazuh/wazuh-qa/files/15273212/artifacts.zip)
