### PR TITLE
Added macOS Sonoma 14.5 beta to allocator

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -126,6 +126,9 @@ vagrant:
   macos-sonoma-14-amd64:
     box: development/macos-sonoma
     box_version: 0.0.0
+  macos-sonoma-14.5-amd64:
+    box: development/macos-sonoma-1450
+    box_version: 0.0.0
   macos-sonoma-14-arm64:
     box: macos-14
     box_version: 0.0.0


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->

The aim of this PR is to add the macOS Intel Sonoma 14.5 beta Vagrant box to the allocator module. Once the box is created in [this](https://github.com/wazuh/wazuh-automation/issues/1651) issue, the new machine is added to the allocator in order to allow the rest of the teams to use it.  

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

The box was added with the name `macos-sonoma-14.5-amd64`, and the allocator was used to test the new box:

```console
> python3 modules/allocation/main.py --action create --provider vagrant --size medium --composite-name macos-sonoma-14.5-amd64 --inventory-output "/tmp/dtt1-poc/sonoma-beta/inventory.yaml" --track-output "/tmp/dtt1-poc/sonoma-beta/track.yaml" --label-issue "https://github.com/wazuh/wazuh-automation/issues/1651"
[2024-05-14 11:08:31] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-05-14 11:08:31] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-05-14 11:08:31] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-05-14 11:08:43] [INFO] ALLOCATOR: Using the macStadium Intel server to deploy.
[2024-05-14 11:08:43] [DEBUG] ALLOCATOR: Checking if instance directory exists on remote host
[2024-05-14 11:08:45] [DEBUG] ALLOCATOR: Creating instance directory on remote host
[2024-05-14 11:08:47] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-14 11:08:47] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-14 11:08:52] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-05-14 11:09:01] [INFO] ALLOCATOR: Instance automation-1651-sonoma-14.5-753 created.
[2024-05-14 11:13:38] [INFO] ALLOCATOR: Instance automation-1651-sonoma-14.5-753 started.
[2024-05-14 11:13:49] [INFO] ALLOCATOR: Inventory file generated at /tmp/dtt1-poc/sonoma-beta/inventory.yaml
[2024-05-14 11:13:52] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-14 11:14:02] [INFO] ALLOCATOR: Track file generated at /tmp/dtt1-poc/sonoma-beta/track.yaml
```
