### PR TITLE
Fixed RPM agent naming for AARCH64 systems

### DIFF
--- a/deployability/modules/testing/tests/helpers/agent.py
+++ b/deployability/modules/testing/tests/helpers/agent.py
@@ -35,7 +35,7 @@ class WazuhAgent:
                 ])
             elif distribution == 'rpm' and 'arm64' in architecture:
                 commands.extend([
-                    f"curl -o wazuh-agent-{wazuh_version}-1aarch64.rpm https://{s3_url}.wazuh.com/{release}/yum/wazuh-agent-{wazuh_version}-1.aarch64.rpm && sudo WAZUH_MANAGER='MANAGER_IP' WAZUH_AGENT_NAME='{agent_name}' rpm -ihv wazuh-agent-{wazuh_version}-1.aarch64.rpm"
+                    f"curl -o wazuh-agent-{wazuh_version}-1.aarch64.rpm https://{s3_url}.wazuh.com/{release}/yum/wazuh-agent-{wazuh_version}-1.aarch64.rpm && sudo WAZUH_MANAGER='MANAGER_IP' WAZUH_AGENT_NAME='{agent_name}' rpm -ihv wazuh-agent-{wazuh_version}-1.aarch64.rpm"
                 ])
             elif distribution == 'deb' and 'amd64' in architecture:
                 commands.extend([
@@ -122,7 +122,7 @@ class WazuhAgent:
         elif os_type == 'macos':
             try:
                 if 'amazonaws' in manager_host and 'amazonaws' in agent_host:
-                    host_ip = HostInformation.get_internal_ip_from_aws_dns(manager_host) 
+                    host_ip = HostInformation.get_internal_ip_from_aws_dns(manager_host)
                 else:
                     host_ip = HostInformation.get_public_ip_from_aws_dns(manager_host)
                 commands = [


### PR DESCRIPTION
# Description

This PR fixes the Wazuh agent naming for AARCH64 systems due to a missing dot before the architecture

- https://packages-dev.wazuh.com/pre-release/yum/wazuh-agent-4.7.4-1.aarch64.rpm

