### PR TITLE
Changed ARM family type to t4g in allocator

### DIFF
--- a/deployability/modules/allocation/static/specs/size.yml
+++ b/deployability/modules/allocation/static/specs/size.yml
@@ -17,21 +17,21 @@ aws:
       type: t2.small
       storage: 20
     arm64:
-      type: a1.medium
+      type: t4g.micro
       storage: 20
   small:
     amd64:
       type: t3.small
       storage: 20
     arm64:
-      type: a1.large
+      type: t4g.small
       storage: 20
   medium:
     amd64:
       type: t3a.medium
       storage: 20
     arm64:
-      type: a1.xlarge
+      type: t4g.medium
       storage: 20
   large:
     amd64:


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->
Closes: https://github.com/wazuh/wazuh-automation/issues/1659
The aim of this PR is to change the ARM family type of the Allocator module from the `a1` family to the `t4g` family. The `a1` family type presented problems in several AMIs, so the family type has been changed to support all the specified AMIs in the allocator.

## Testing performed

All the AMIs specified in the Allocator module have been tested with this new family type:
- Testing all AMIs with one size: https://github.com/wazuh/wazuh-automation/issues/1659#issuecomment-2113241361
- Testing all sizes with one AMI: https://github.com/wazuh/wazuh-automation/issues/1659#issuecomment-2113241361