### PR TITLE
Added known issues paragraph to allocation documentation

### DIFF
--- a/deployability/modules/allocation/README.MD
+++ b/deployability/modules/allocation/README.MD
@@ -370,9 +370,9 @@ python3 modules/allocation/main.py --action create --provider vagrant --size lar
 
 Currently, the Allocation module may encounter the following issues:
 
-1. **Rocky Linux 9 ARM instance fails to start with micro size on AWS**
+1. **Rocky Linux 9 ARM instance fails to start with `micro` size on AWS**
 
-   - **Issue:** When attempting to launch a Rocky Linux 9 ARM instance on AWS using the micro size, the instance fails to start. This occurs because the specified micro size is not supported by the AMI.
+   - **Issue:** When attempting to launch a Rocky Linux 9 ARM instance on AWS using the `micro` size, the instance fails to start. This occurs because the specified `micro` size is not supported by the AMI.
    - **Symptoms:** The Allocator module fails to launch the instance. The error reported says that "The instance configuration for this AWS Marketplace product is not supported".
    - **Workaround:**: This AMI does not support the `micro` size. Choose the `small` size or higher to launch this instance.
 

--- a/deployability/modules/allocation/README.MD
+++ b/deployability/modules/allocation/README.MD
@@ -366,6 +366,16 @@ python3 modules/allocation/main.py --action create --provider vagrant --size lar
 
 [Allocation.drawio.zip](https://github.com/wazuh/wazuh-qa/files/14868775/Allocation.drawio.zip)
 
+### Known issues
+
+Currently, the Allocation module may encounter the following issues:
+
+1. **Rocky Linux 9 ARM instance fails to start with micro size on AWS**
+
+   - **Issue:** When attempting to launch a Rocky Linux 9 ARM instance on AWS using the micro size, the instance fails to start. This occurs because the specified micro size is not supported by the AMI.
+   - **Symptoms:** The Allocator module fails to launch the instance. The error reported says that "The instance configuration for this AWS Marketplace product is not supported".
+   - **Workaround:**: This AMI does not support the `micro` size. Choose the `small` size or higher to launch this instance.
+
 
 ### License
 


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->

---

Related: https://github.com/wazuh/wazuh-automation/issues/1659
The aim of this PR is to add the `Known issues` paragraph to the Allocator documentation. In this case, the issue added was encountered in the mentioned issue. 
The encountered behavior is that the Rocky Linux 9 ARM instance can not be used with the `micro` size. This behavior has been added to the new documentation block.

This documentation block will contain all the known issues of the Allocator that can not be fixed, or known behaviors of the tool.