### PR TITLE
Fix multigroups guess system test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix multigroups guess system test ([#5396](https://github.com/wazuh/wazuh-qa/pull/5396)) \- (Tests)
 - Fix restart agent in change manager Vulnerability Detector E2E test case ([#5355](https://github.com/wazuh/wazuh-qa/pull/5355)) \- (Tests)
 - Fix E2E Vulnerability Detection Windows package installation error ([#5363](https://github.com/wazuh/wazuh-qa/pull/5363)) \- (Framework)
 - Fix shutdown messages system test ([#5298](https://github.com/wazuh/wazuh-qa/pull/5298)) \- (Framework + Tests)

--- a/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
+++ b/tests/system/test_cluster/test_agent_groups/test_assign_groups_guess.py
@@ -48,6 +48,7 @@ from system.test_cluster.test_agent_groups.common import register_agent
 from system import (ERR_MSG_CLIENT_KEYS_IN_MASTER_NOT_FOUND, check_agent_groups, check_keys_file,
                     create_new_agent_group, delete_agent_group, remove_cluster_agents,
                     assign_agent_to_new_group, restart_cluster)
+from wazuh_testing import T_10, T_20
 from wazuh_testing.tools.system import HostManager
 from wazuh_testing.tools.file import replace_regex_in_file
 from wazuh_testing.tools.system_monitoring import HostMonitor
@@ -73,8 +74,6 @@ tmp_path = os.path.join(local_path, 'tmp')
 # Variables
 group_id = 'group_test'
 multigroups_id = 'default,group_test'
-# this timeout is temporality, this test will be update
-timeout = 20
 
 
 # Fixtures
@@ -135,7 +134,7 @@ def test_guess_single_group(target_node, status_guess_agent_group, clean_environ
     '''
     # Restart master to apply local internal options
     restart_cluster([test_infra_managers[0]], host_manager)
-    time.sleep(timeout)
+    time.sleep(T_20)
 
     # Create new group
     create_new_agent_group(test_infra_managers[0], group_id, host_manager)
@@ -156,7 +155,7 @@ def test_guess_single_group(target_node, status_guess_agent_group, clean_environ
         # Remove agent from default to test single group guess (not multigroup)
         host_manager.run_command(test_infra_managers[0], f"/var/ossec/bin/agent_groups -q -r -i {agent_id} -g default")
 
-        time.sleep(timeout)
+        time.sleep(T_20)
 
         # Check that agent has group set to group_test on Managers
         check_agent_groups(agent_id, group_id, test_infra_managers, host_manager)
@@ -173,7 +172,7 @@ def test_guess_single_group(target_node, status_guess_agent_group, clean_environ
 
         # Restart agent
         restart_cluster([test_infra_agents[0]], host_manager)
-        time.sleep(timeout)
+        time.sleep(T_20)
 
         # Check if remoted.guess_agent_group is disabled
         expected_group = 'default' if int(status_guess_agent_group) == 0 else group_id
@@ -228,7 +227,7 @@ def test_guess_multigroups(n_agents, target_node, status_guess_agent_group, clea
     '''
     # Restart master to apply local internal options
     restart_cluster([test_infra_managers[0]], host_manager)
-    time.sleep(timeout)
+    time.sleep(T_20)
 
     # Create new group
     create_new_agent_group(test_infra_managers[0], group_id, host_manager)
@@ -241,6 +240,7 @@ def test_guess_multigroups(n_agents, target_node, status_guess_agent_group, clea
 
     # Restart agent
     restart_cluster(test_infra_agents, host_manager)
+    time.sleep(T_10)
 
     # Check that agent has client key file
     for agent in range(n_agents):
@@ -250,7 +250,7 @@ def test_guess_multigroups(n_agents, target_node, status_guess_agent_group, clea
         # Create new group and assing agent
         for agent in range(n_agents):
             assign_agent_to_new_group(test_infra_managers[0], group_id, agents_data[agent][1], host_manager)
-        time.sleep(timeout)
+        time.sleep(T_20)
 
         # Check that agent has group set to group_test on Managers
         for agent in range(n_agents):
@@ -268,7 +268,7 @@ def test_guess_multigroups(n_agents, target_node, status_guess_agent_group, clea
 
         # Restart agent
         restart_cluster([test_infra_agents[0]], host_manager)
-        time.sleep(timeout)
+        time.sleep(T_20)
 
         # Check if remoted.guess_agent_group is disabled
         expected_group = 'default' if int(status_guess_agent_group) == 0 or n_agents == 1 else multigroups_id


### PR DESCRIPTION
|Related issue|
|:--:|
| #5395 |

## Description
A 10 second wait has been added so that the agent has time to send a first keep alive and be assigned the `default` group.

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->


| Validation | Jenkins | Local    | Commit | Notes                |
|--------------------|-----------|------------|-----|--------|
|  `tests/system -m enrollment_cluster_env`         | 🚫  | [🟢 ](https://github.com/wazuh/wazuh-qa/files/15347961/enrollment_cluster_env.zip) |        00cf84f8e07a79ac67a9ae0734c2448d561cbc39     | Nothing to highlight |