### PR TITLE
Added virtualizer parameter for AWS

### DIFF
--- a/deployability/modules/allocation/allocation.py
+++ b/deployability/modules/allocation/allocation.py
@@ -184,7 +184,7 @@ class Allocator:
                                     ssh_port=port,
                                     platform=instance.platform,
                                     arch=instance.arch,
-                                    virtualizer=instance.virtualizer)
+                                    virtualizer=str(instance.virtualizer))
         track_path = Path(os.path.join(instance.path, 'track.yaml'))
         with open(track_path, 'w') as f:
             yaml.dump(track.model_dump(), f)

--- a/deployability/modules/allocation/aws/instance.py
+++ b/deployability/modules/allocation/aws/instance.py
@@ -43,6 +43,7 @@ class AWSInstance(Instance):
         self.arch = instance_parameters.arch
         self.ssh_port = instance_parameters.ssh_port
         self._user = instance_parameters.user
+        self.virtualizer = instance_parameters.virtualizer
 
     def start(self) -> None:
         """Start the AWS EC2 instance."""

--- a/deployability/modules/allocation/generic/instance.py
+++ b/deployability/modules/allocation/generic/instance.py
@@ -51,6 +51,7 @@ class Instance(ABC):
         self.platform: str = instance_parameters.platform
         self.arch: str = instance_parameters.arch
         self.user: str = instance_parameters.user
+        self.virtualizer: str = instance_parameters.virtualizer
 
     @abstractmethod
     def start(self) -> None:


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-qa/issues/5399

The virtualizer parameter was added to fix the bug.

AWS test:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action create --provider aws --size large --composite-name linux-ubuntu-22.04-arm64 --label-team core --label-termination-date 1d --working-dir /tmp/allocatorvm --track-output /tmp/allocatorvm/track.yml --inventory-output /tmp/allocatorvm/inventory.yml --instance-name cbordon-tes
[2024-05-17 08:58:06] [INFO] ALLOCATOR: Creating instance at /tmp/allocatorvm
[2024-05-17 08:58:06] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-17 08:58:06] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-17 08:58:06] [DEBUG] ALLOCATOR: Creating base directory: /tmp/allocatorvm/AWS-B942B2FD-83F0-411B-9B14-CFD1EF683F03
[2024-05-17 08:58:26] [DEBUG] ALLOCATOR: Renaming temp /tmp/allocatorvm/AWS-B942B2FD-83F0-411B-9B14-CFD1EF683F03 directory to /tmp/allocatorvm/i-0baf27d651b4a9506
[2024-05-17 08:58:26] [INFO] ALLOCATOR: Instance i-0baf27d651b4a9506 created.
[2024-05-17 08:58:28] [INFO] ALLOCATOR: Instance i-0baf27d651b4a9506 started.
[2024-05-17 08:58:28] [INFO] ALLOCATOR: The inventory file generated at /tmp/allocatorvm/inventory.yml
[2024-05-17 08:58:28] [INFO] ALLOCATOR: The track file generated at /tmp/allocatorvm/track.yml
[2024-05-17 08:58:28] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 54.147.31.172
[2024-05-17 08:59:00] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-17 08:59:00] [INFO] ALLOCATOR: Instance i-0baf27d651b4a9506 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/allocatorvm/track.yml
arch: arm64
host_identifier: None
host_instance_dir: None
identifier: i-0baf27d651b4a9506
instance_dir: /tmp/allocatorvm/i-0baf27d651b4a9506
key_path: /tmp/allocatorvm/i-0baf27d651b4a9506/cbordon-tes-key-8168
platform: linux
provider: aws
ssh_port: 2200
virtualizer: None
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/allocatorvm/track.yml
[2024-05-17 08:59:10] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/allocatorvm/track.yml
[2024-05-17 08:59:11] [DEBUG] ALLOCATOR: Deleting credentials: cbordon-tes-key-8168
[2024-05-17 09:00:14] [INFO] ALLOCATOR: Instance i-0baf27d651b4a9506 deleted.
```

Vagrant test:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action create --provider vagrant --size large --composite-name linux-ubuntu-22.04-amd64 --label-team core --label-termination-date 1d --working-dir /tmp/allocatorvm --track-output /tmp/allocatorvm/track.yml --inventory-output /tmp/allocatorvm/inventory.yml --instance-name cbordon-test
[2024-05-17 09:00:37] [INFO] ALLOCATOR: Creating instance at /tmp/allocatorvm
[2024-05-17 09:00:38] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-17 09:00:38] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-17 09:00:41] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-05-17 09:00:41] [INFO] ALLOCATOR: Instance cbordon-test-515 created.
[2024-05-17 09:01:24] [ERROR] ALLOCATOR: Command failed: ==> vagrant: A new version of Vagrant is available: 2.4.1 (installed version: 2.3.4)!
==> vagrant: To upgrade visit: https://www.vagrantup.com/downloads.html


[2024-05-17 09:01:24] [INFO] ALLOCATOR: Instance cbordon-test-515 started.
[2024-05-17 09:01:26] [INFO] ALLOCATOR: The inventory file generated at /tmp/allocatorvm/inventory.yml
[2024-05-17 09:01:26] [INFO] ALLOCATOR: The track file generated at /tmp/allocatorvm/track.yml
[2024-05-17 09:01:26] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-17 09:01:26] [INFO] ALLOCATOR: Instance cbordon-test-515 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/allocatorvm/track.yml
arch: amd64
host_identifier: None
host_instance_dir: None
identifier: cbordon-test-515
instance_dir: /tmp/allocatorvm/cbordon-test-515
key_path: /tmp/allocatorvm/cbordon-test-515/instance_key
platform: linux
provider: vagrant
ssh_port: 22
virtualizer: virtualbox
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/allocatorvm/track.yml
[2024-05-17 09:01:37] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/allocatorvm/track.yml
[2024-05-17 09:01:37] [DEBUG] ALLOCATOR: Destroying instance cbordon-test-515
[2024-05-17 09:01:43] [INFO] ALLOCATOR: Instance cbordon-test-515 deleted.
```