### PR TITLE
Increase E2E Vulnerability initial scan tests timeout

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
@@ -28,8 +28,8 @@ from wazuh_testing.end_to_end.regex import REGEX_PATTERNS
 from collections import namedtuple
 
 
-PACKAGE_VULNERABILITY_SCAN_TIME = 60
-TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN = PACKAGE_VULNERABILITY_SCAN_TIME * 3
+PACKAGE_VULNERABILITY_SCAN_TIME = 160
+TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN = 240
 
 Vulnerability = namedtuple('Vulnerability', ['cve', 'package_name', 'package_version', 'architecture'])
 

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -66,6 +66,7 @@ from wazuh_testing.end_to_end.remote_operations_handler import (
 from wazuh_testing.end_to_end.utils import (extract_case_info, get_case_ids,
                                             load_test_cases)
 from wazuh_testing.end_to_end.vulnerability_detector import (TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN,
+                                                             PACKAGE_VULNERABILITY_SCAN_TIME,
                                                              get_vulnerabilities_from_states_by_agent)
 from wazuh_testing.end_to_end.waiters import wait_until_vd_is_updated
 from wazuh_testing.tools.system import HostManager
@@ -77,7 +78,6 @@ AGENTS_SCANNED_FIRST_SCAN = []
 FIRST_SCAN_TIME = None
 FIRST_SCAN_VULNERABILITIES_INDEX = {}
 AGENT_REGISTRATION_TIMEOUT = 15
-PACKAGE_VULNERABILITY_SCAN_TIME = 120
 
 VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS = [
     r"Invalid ID \d{3} for the source",


### PR DESCRIPTION
# Description

This PR increases the initial scan timeout from 180 to 240 in order to ensure index consistency between the first and second syscollector scans.

---

## Testing performed


|OS|Package used|
|--|--|
|||

| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | ⚫⚫ | ⚫⚫ |         |         | Nothing to highlight |