### PR TITLE
Increase feed update time in Vulnerability Detection E2E tests to 10h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Increase feed update time in Vulnerability Detection E2E tests to 10h ([#5424](https://github.com/wazuh/wazuh-qa/pull/5424)) \- (Tests)
 - Migrate E2E Vulnerability Detector test packages to S3 repository ([#5376](https://github.com/wazuh/wazuh-qa/pull/5376)) \- (Framework)
 - Include "Agent key already in use" in the E2E Vulnerability Detection expected error list. ([#5409](https://github.com/wazuh/wazuh-qa/pull/5409)) \- (Tests)
 - Update vulnerability state index name ([#5402](https://github.com/wazuh/wazuh-qa/pull/5402)) \- (Framework)

--- a/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
@@ -6,7 +6,7 @@
         - index-status:
             value: 'yes'
         - feed-update-interval:
-            value: 2h
+            value: 10h
     - section: indexer
       elements:
         - enabled:
@@ -46,4 +46,3 @@
       elements:
         - disabled:
             value: 'no'
-


### PR DESCRIPTION
# Description

This PR increases the feed update interval in the E2E Vulnerability Detection tests to 10 hours, preventing feed updates from occurring during the initial scan tests.

## Testing performed

Build: https://ci.wazuh.info/job/Test_e2e_system/290