### PR TITLE
Added Ubuntu 24.04 AMD64 and ARM64 to the Allocator

### DIFF
--- a/deployability/modules/allocation/aws/helpers/userData.sh
+++ b/deployability/modules/allocation/aws/helpers/userData.sh
@@ -162,7 +162,13 @@ fi
 
 if [ "$DIST_NAME" = "ubuntu" ] || [ "$DIST_NAME" = "debian" ]; then
     perl -pi -e "s/^#?Port 22$/Port ${SSH_PORT}/" /etc/ssh/sshd_config
-    service sshd restart || service ssh restart
+    if [ "$DIST_VER" = "24" ]; then
+        perl -pi -e "s/^#?ListenStream=22$/ListenStream=${SSH_PORT}/" /etc/systemd/system/sockets.target.wants/ssh.socket
+        systemctl daemon-reload
+        systemctl restart sshd || systemctl restart ssh 
+    else
+        service sshd restart || service ssh restart
+    fi
 fi
 
 if [ "$DIST_NAME" = "darwin" ]; then

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -209,6 +209,14 @@ vagrant:
 
 aws:
   # Ubuntu
+  linux-ubuntu-24.04-amd64:
+    ami: ami-04b70fa74e45c3917
+    zone: us-east-1
+    user: ubuntu
+  linux-ubuntu-24.04-arm64:
+    ami: ami-0eac975a54dfee8cb
+    zone: us-east-1
+    user: ubuntu
   linux-ubuntu-22.04-amd64:
     ami: ami-053b0d53c279acc90
     zone: us-east-1


### PR DESCRIPTION
## Description

The aim of this PR is to add the Ubuntu 24.04 AMD64 and ARM64 instances to the Allocator module.

- The chosen AMIs were selected from the community AMIs
- Some changes have been performed to the userData script in order to perform the SSH port change.

## Testing

```console
>  python3 modules/allocation/main.py --action create --provider aws --size micro --composite-name linux-ubuntu-24.04-amd64 --inventory-output "/tmp/dtt1-poc/test-ubuntu-24-amd/inventory.yaml" --track-output "/tmp/dtt1-poc/test-ubuntu-24-amd/track.yaml" --label-issue "https://github.com/wazuh/wazuh-qa/issues/5425" --label-termination-date "1d" --label-team "devops"
[2024-05-23 18:03:10] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-05-23 18:03:10] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-05-23 18:03:10] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-05-23 18:03:11] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-23 18:03:11] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-23 18:03:11] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-BDFD2ACC-FD47-4DD4-AC20-7466F7C983CA
[2024-05-23 18:03:45] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-BDFD2ACC-FD47-4DD4-AC20-7466F7C983CA directory to /tmp/wazuh-qa/i-059de0883a57d5918
[2024-05-23 18:03:45] [INFO] ALLOCATOR: Instance i-059de0883a57d5918 created.
[2024-05-23 18:03:47] [INFO] ALLOCATOR: Instance i-059de0883a57d5918 started.
[2024-05-23 18:03:48] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/test-ubuntu-24-amd/inventory.yaml
[2024-05-23 18:03:48] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/test-ubuntu-24-amd/track.yaml
[2024-05-23 18:03:50] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 18.212.59.196
[2024-05-23 18:04:21] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-23 18:04:21] [INFO] ALLOCATOR: Instance i-059de0883a57d5918 created successfully.
```

```console
>  python3 modules/allocation/main.py --action create --provider aws --size micro --composite-name linux-ubuntu-24.04-arm64 --inventory-output "/tmp/dtt1-poc/test-ubuntu-24-arm/inventory.yaml" --track-output "/tmp/dtt1-poc/test-ubuntu-24-arm/track.yaml" --label-issue "https://github.com/wazuh/wazuh-qa/issues/5425" --label-termination-date "1d" --label-team "devops"
[2024-05-23 18:36:02] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-05-23 18:36:03] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-23 18:36:03] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-23 18:36:03] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-284704CA-BD31-4EF6-BD94-BE6ED2533D7E
[2024-05-23 18:36:23] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-284704CA-BD31-4EF6-BD94-BE6ED2533D7E directory to /tmp/wazuh-qa/i-03dfaf203b30bdc12
[2024-05-23 18:36:23] [INFO] ALLOCATOR: Instance i-03dfaf203b30bdc12 created.
[2024-05-23 18:36:24] [INFO] ALLOCATOR: Instance i-03dfaf203b30bdc12 started.
[2024-05-23 18:36:24] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/test-ubuntu-24-arm/inventory.yaml
[2024-05-23 18:36:24] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/test-ubuntu-24-arm/track.yaml
[2024-05-23 18:36:25] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 54.152.255.55
[2024-05-23 18:36:56] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-23 18:36:56] [INFO] ALLOCATOR: Instance i-03dfaf203b30bdc12 created successfully.
```
