### PR TITLE
Check 'client.keys' existence after deletion in agentd integration test

### DIFF
--- a/tests/integration/test_agentd/test_agentd_reconnection.py
+++ b/tests/integration/test_agentd/test_agentd_reconnection.py
@@ -177,6 +177,8 @@ def delete_keys():
     """Remove the agent's client.keys file."""
     os.remove(CLIENT_KEYS_PATH)
     sleep(1)
+    if os.path.exists(CLIENT_KEYS_PATH):
+        raise Exception(f"'{CLIENT_KEYS_PATH}' could not be removed")
 
 
 def set_keys():


### PR DESCRIPTION
|Related issue|
|-------------|
|      https://github.com/wazuh/wazuh/issues/23465        |

# Description

It has been seen in https://github.com/wazuh/wazuh/issues/23465 that randomly fails the `test_agentd_reconection_enrollment_no_keys_file`. 
Although it could not be replicated, it is observed in the logs that apparently _'client.keys'_ file is not being deleted. This causes the agent to connect directly to the manager (with the valid key) skipping the enrollment process and so the test fails. 
This PR adds an extra check after deleting _'client.keys'_ file and in case the file exists an exception is raised.

### Updated

- `tests/integration/test_agentd/test_agentd_reconnection.py`

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

| Tester | Test path | Jenkins | Local  | OS  | Commit | Notes                |
|----------|--------------------|-----------|---------|--------|-----|--------|
| @nbertoldo (Developer) | `tests\integration\test_agentd` | ⚫⚫ | [🟢🟢](https://github.com/wazuh/wazuh-qa/files/15422452/Report.zip) | Windows Server 2016 | [1cbc994](https://github.com/wazuh/wazuh-qa/pull/5429/commits/1cbc994be32295a066735f8b4aa59fe4aa54754f) | Nothing to highlight |
| @cborla (Reviewer) | `tests\integration\test_agentd` | [🟢🟢](https://ci.wazuh.info/job/Test_integration/47451/) | ⚫⚫ | Centos 8 | [1cbc994](https://github.com/wazuh/wazuh-qa/pull/5429/commits/1cbc994be32295a066735f8b4aa59fe4aa54754f) | Nothing to highlight |
| @cborla (Reviewer) | `tests\integration\test_agentd` | [🟢🟢](https://ci.wazuh.info/job/Test_integration/47451/) | ⚫⚫ | Windows Server 2016 | [1cbc994](https://github.com/wazuh/wazuh-qa/pull/5429/commits/1cbc994be32295a066735f8b4aa59fe4aa54754f) | Nothing to highlight |

