### PR TITLE
Updated Rocky Linux 9 OSs in the Allocator module

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -125,8 +125,8 @@ vagrant:
     box_version: 4.3.12
     virtualizer: virtualbox
   linux-rocky-9-amd64:
-    box: generic/rocky9
-    box_version: 4.3.12
+    box: rockylinux/9
+    box_version: 4.0.0
     virtualizer: virtualbox
   # Macos
   macos-highsierra-10.13-amd64:
@@ -391,11 +391,11 @@ aws:
     zone: us-east-1
     user: rocky
   linux-rocky-9-amd64:
-    ami: ami-09c77dc92e45bc3ea
+    ami: ami-09eb79aa215c2a900
     zone: us-east-1
     user: rocky
   linux-rocky-9-arm64:
-    ami: ami-001f90eb122403b4c
+    ami: ami-0151988e287370acc
     zone: us-east-1
     user: rocky
   # Macos


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->

---
Closes: https://github.com/wazuh/wazuh-qa/issues/5435
The aim of this PR is to update the Rocky Linux 9 OSs specified in the Allocator, upgrading them to the 9.4 Rocky Linux version.

## Testing

<details><summary>:green_circle: Launching Rocky Linux 9 AMD64 - AWS</summary>

```console
> python3 modules/allocation/main.py --action create --provider aws --size micro --composite-name linux-rocky-9-amd64 --inventory-output "/tmp/dtt1-poc/test-linux-rocky-9-amd64/inventory.yaml" --track-output "/tmp/dtt1-poc/test-linux-rocky-9-amd64/track.yaml" --label-issue "https://github.com/wazuh/wazuh-qa/issues/5435" --label-termination-date "1d" --label-team "devops"
[2024-05-28 13:54:04] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-05-28 13:54:04] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-05-28 13:54:04] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-05-28 13:54:06] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-28 13:54:06] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-28 13:54:06] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-E0AB50A6-FB17-4FFF-BB42-DC3FBA5A1C5F
[2024-05-28 13:54:40] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-E0AB50A6-FB17-4FFF-BB42-DC3FBA5A1C5F directory to /tmp/wazuh-qa/i-09ff8226cb228368d
[2024-05-28 13:54:40] [INFO] ALLOCATOR: Instance i-09ff8226cb228368d created.
[2024-05-28 13:54:41] [INFO] ALLOCATOR: Instance i-09ff8226cb228368d started.
[2024-05-28 13:54:41] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/test-linux-rocky-9-amd64/inventory.yaml
[2024-05-28 13:54:41] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/test-linux-rocky-9-amd64/track.yaml
[2024-05-28 13:55:51] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-28 13:55:51] [INFO] ALLOCATOR: Instance i-09ff8226cb228368d created successfully.
```
</details>


<details><summary>:green_circle: Launching Rocky Linux 9 ARM64 - AWS</summary>

```console
> python3 modules/allocation/main.py --action create --provider aws --size micro --composite-name linux-rocky-9-arm64 --inventory-output "/tmp/dtt1-poc/test-linux-rocky-9-arm64/inventory.yaml" --track-output "/tmp/dtt1-poc/test-linux-rocky-9-arm64/track.yaml" --label-issue "https://github.com/wazuh/wazuh-qa/issues/5435" --label-termination-date "1d" --label-team "devops"
[2024-05-28 13:54:18] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-05-28 13:54:18] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-05-28 13:54:18] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-05-28 13:54:19] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-28 13:54:19] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-28 13:54:19] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-BD62A592-129F-4871-A06F-6A8C4426AD63
[2024-05-28 13:54:40] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-BD62A592-129F-4871-A06F-6A8C4426AD63 directory to /tmp/wazuh-qa/i-0b22e19c61d8056a6
[2024-05-28 13:54:40] [INFO] ALLOCATOR: Instance i-0b22e19c61d8056a6 created.
[2024-05-28 13:54:41] [INFO] ALLOCATOR: Instance i-0b22e19c61d8056a6 started.
[2024-05-28 13:54:41] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/test-linux-rocky-9-arm64/inventory.yaml
[2024-05-28 13:54:41] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/test-linux-rocky-9-arm64/track.yaml
[2024-05-28 13:55:50] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 107.23.149.167
[2024-05-28 13:56:21] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-28 13:56:21] [INFO] ALLOCATOR: Instance i-0b22e19c61d8056a6 created successfully.
```

```console
[rocky@ip-172-31-18-216 ~]$ cat /etc/os-release 
NAME="Rocky Linux"
VERSION="9.4 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.4"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Rocky Linux 9.4 (Blue Onyx)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2032-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
ROCKY_SUPPORT_PRODUCT_VERSION="9.4"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.4"
[rocky@ip-172-31-18-216 ~]$ 

```console
[rocky@ip-172-31-81-155 ~]$ cat /etc/os-release 
NAME="Rocky Linux"
VERSION="9.4 (Blue Onyx)"
ID="rocky"
ID_LIKE="rhel centos fedora"
VERSION_ID="9.4"
PLATFORM_ID="platform:el9"
PRETTY_NAME="Rocky Linux 9.4 (Blue Onyx)"
ANSI_COLOR="0;32"
LOGO="fedora-logo-icon"
CPE_NAME="cpe:/o:rocky:rocky:9::baseos"
HOME_URL="https://rockylinux.org/"
BUG_REPORT_URL="https://bugs.rockylinux.org/"
SUPPORT_END="2032-05-31"
ROCKY_SUPPORT_PRODUCT="Rocky-Linux-9"
ROCKY_SUPPORT_PRODUCT_VERSION="9.4"
REDHAT_SUPPORT_PRODUCT="Rocky Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="9.4"
[rocky@ip-172-31-81-155 ~]$ 

```
</details>


<details><summary>:green_circle: Launching Rocky Linux 9 AMD64 - Vagrant</summary>

```console
> python3 modules/allocation/main.py --action create --provider vagrant --size micro --composite-name linux-rocky-9-amd64 --inventory-output "/tmp/dtt1-poc/test-linux-rocky-9-amd64/inventory.yaml" --track-output "/tmp/dtt1-poc/test-linux-rocky-9-amd64/track.yaml" --label-issue "https://github.com/wazuh/wazuh-qa/issues/5435" --label-termination-date "1d" --label-team "devops"
[2024-05-28 14:14:32] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-05-28 14:14:32] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-05-28 14:14:33] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-05-28 14:14:33] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-05-28 14:14:33] [DEBUG] ALLOCATOR: Generating new key pair
[2024-05-28 14:14:37] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-05-28 14:14:37] [INFO] ALLOCATOR: Instance qa-5435-rocky-9-8702 created.
[2024-05-28 14:21:02] [INFO] ALLOCATOR: Instance qa-5435-rocky-9-8702 started.
[2024-05-28 14:21:21] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/test-linux-rocky-9-amd64/inventory.yaml
[2024-05-28 14:21:21] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/test-linux-rocky-9-amd64/track.yaml
[2024-05-28 14:21:21] [INFO] ALLOCATOR: SSH connection successful.
[2024-05-28 14:21:21] [INFO] ALLOCATOR: Instance qa-5435-rocky-9-8702 created successfully.

```
</details>