### PR TITLE
Fix logcollector integration test for Windows agent

### DIFF
--- a/tests/integration/test_logcollector/test_log_filter_options/test_ignore_regex.py
+++ b/tests/integration/test_logcollector/test_log_filter_options/test_ignore_regex.py
@@ -69,7 +69,7 @@ CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
 TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
 
 # Test configurations and cases data
-test_file = os.path.join(PREFIX, 'test')
+test_file = os.path.join(PREFIX, 'test.log')
 
 # --------------------------------TEST_IGNORE_MULTIPLE_REGEX-------------------------------------------
 configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_ignore_multiple_regex.yaml')

--- a/tests/integration/test_logcollector/test_log_filter_options/test_restrict_ignore_regex.py
+++ b/tests/integration/test_logcollector/test_log_filter_options/test_restrict_ignore_regex.py
@@ -75,7 +75,7 @@ configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_restrict_
 cases_path = os.path.join(TEST_CASES_PATH, 'cases_restrict_ignore_regex_values.yaml')
 
 # Test configurations
-test_file = os.path.join(PREFIX, 'test')
+test_file = os.path.join(PREFIX, 'test.log')
 
 configuration_parameters, configuration_metadata, case_ids = get_test_cases_data(cases_path)
 for count, value in enumerate(configuration_parameters):

--- a/tests/integration/test_logcollector/test_log_filter_options/test_restrict_regex.py
+++ b/tests/integration/test_logcollector/test_log_filter_options/test_restrict_regex.py
@@ -70,7 +70,7 @@ CONFIGURATIONS_PATH = os.path.join(TEST_DATA_PATH, 'configuration_template')
 TEST_CASES_PATH = os.path.join(TEST_DATA_PATH, 'test_cases')
 
 # Test configurations and cases data
-test_file = os.path.join(PREFIX, 'test')
+test_file = os.path.join(PREFIX, 'test.log')
 
 # --------------------------------TEST_RESTRICT_MULTIPLE_REGEX-------------------------------------------
 configurations_path = os.path.join(CONFIGURATIONS_PATH, 'configuration_restrict_multiple_regex.yaml')


### PR DESCRIPTION
# Description

This PR closes #4840. It has been verified that logcollector integration tests are creating a test file without extension `C:test`. This causes an error if a folder with that name exists in the directory:

```bash
PermissionError: [Errno 13] Permission denied: 'c:\\test'
```

The extension (`C:\test.log`) has been added to make the tests more robust. 


## Testing performed

| Tester | Test path | Jenkins | Local  | OS  | Commit | Notes                |
|---------- |--------------------|-----------|---------|--------|-----|--------|
| @nbertoldo (Developer) | `tests/integration/test_logcollector/test_log_filter_options` | ⚫⚫ | [🟢](https://github.com/user-attachments/files/15570665/report.zip) | Windows Server 2016 | [b370977](https://github.com/wazuh/wazuh-qa/pull/5461/commits/b370977f1221e4ad0cf13cb062d66eb197f578b2) |  |

