### PR TITLE
Fixed Device name for AWS deployment

### DIFF
--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -190,10 +190,14 @@ class AWSProvider(Provider):
         Returns:
             str: Identifier of the created instance.
         """
-        client = boto3.resource('ec2')
+        client = boto3.client('ec2')
+        resource = boto3.resource('ec2')
 
         userData_file = Path(__file__).parent.parent / 'aws' / 'helpers' / 'userData.sh'
         windosUserData_file = Path(__file__).parent.parent / 'aws' / 'helpers' / 'windowsUserData.ps1'
+        # Describe the AMI to get the root device name
+        ami = client.describe_images(ImageIds=[config.ami])
+        root_device_name = ami['Images'][0]['RootDeviceName']
 
         if config.platform == 'windows':
             with open(windosUserData_file, 'r') as file:
@@ -209,7 +213,7 @@ class AWSProvider(Provider):
             'SecurityGroupIds': config.security_groups,
             'BlockDeviceMappings': [
                 {
-                    'DeviceName': '/dev/sda1',
+                    'DeviceName': root_device_name,
                     'Ebs': {
 
                         'DeleteOnTermination': True,
@@ -240,7 +244,7 @@ class AWSProvider(Provider):
         if config.issue:
             params['TagSpecifications'][0]['Tags'].append({'Key': 'issue', 'Value': config.issue})
 
-        instance = client.create_instances(**params)[0]
+        instance = resource.create_instances(**params)[0]
         # Wait until the instance is running.
         instance.wait_until_running()
         return instance.instance_id


### PR DESCRIPTION
Close:https://github.com/wazuh/wazuh-qa/issues/5464

## Description

This PR aims to solve the issue with Device Name in AWS deployments:

## Tests

### Debian 10

<details>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action=create --provider=aws --size=medium --label-issue https://github.com/wazuh/wazuh/issues/23869 --label-termination-date 1d --label-team devops --composite-name linux-debian-10-amd64
[2024-06-06 10:51:43] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-06 10:51:43] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-06 10:51:43] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-06 10:51:43] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-5E6B63CF-75C3-4283-A35F-66747F25C5C7
[2024-06-06 10:52:04] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-5E6B63CF-75C3-4283-A35F-66747F25C5C7 directory to /tmp/wazuh-qa/i-0ee853da186e7aa4a
[2024-06-06 10:52:04] [INFO] ALLOCATOR: Instance i-0ee853da186e7aa4a created.
[2024-06-06 10:52:06] [INFO] ALLOCATOR: Instance i-0ee853da186e7aa4a started.
[2024-06-06 10:52:06] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/i-0ee853da186e7aa4a/inventory.yaml
[2024-06-06 10:52:06] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/i-0ee853da186e7aa4a/track.yaml
[2024-06-06 10:52:08] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 3.81.89.161
[2024-06-06 10:52:39] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-06 10:52:39] [INFO] ALLOCATOR: Instance i-0ee853da186e7aa4a created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-0ee853da186e7aa4a/inventory.yaml
ansible_connection: ssh
ansible_host: ec2-3-81-89-161.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/i-0ee853da186e7aa4a/wazuh-23869-debian-10-key-2930
ansible_user: admin
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -o StrictHostKeyChecking=no -i /tmp/wazuh-qa/i-0ee853da186e7aa4a/wazuh-23869-debian-10-key-2930 -p 2200 admin@ec2-3-81-89-161.compute-1.amazonaws.com
Warning: Permanently added '[ec2-3-81-89-161.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Linux ip-172-31-38-156 4.19.0-25-cloud-amd64 #1 SMP Debian 4.19.289-2 (2023-08-08) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
admin@ip-172-31-38-156:~$ df -h
Filesystem       Size  Used Avail Use% Mounted on
udev             1.9G     0  1.9G   0% /dev
tmpfs            391M  5.3M  385M   2% /run
/dev/nvme0n1p1    20G  649M   18G   4% /
tmpfs            2.0G     0  2.0G   0% /dev/shm
tmpfs            5.0M     0  5.0M   0% /run/lock
tmpfs            2.0G     0  2.0G   0% /sys/fs/cgroup
/dev/nvme0n1p15  124M  278K  124M   1% /boot/efi
tmpfs            391M     0  391M   0% /run/user/1000
admin@ip-172-31-38-156:~$ exit
logout
Connection to ec2-3-81-89-161.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-0ee853da186e7aa4a/track.yaml 
[2024-06-06 10:54:35] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-0ee853da186e7aa4a/track.yaml
[2024-06-06 10:54:36] [DEBUG] ALLOCATOR: Deleting credentials: wazuh-23869-debian-10-key-2930
[2024-06-06 10:55:23] [INFO] ALLOCATOR: Instance i-0ee853da186e7aa4a deleted.
```
![Screenshot_20240606_105417](https://github.com/wazuh/wazuh-qa/assets/64099752/d81cece4-df42-4a05-aa6c-6652cfb1b886)

</details>

### Debian 11

<details>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action=create --provider=aws --size=medium --label-issue https://github.com/wazuh/wazuh-qa/issues/5464 --label-termination-date 1d --label-team devops --composite-name linux-debian-11-amd64
[2024-06-06 10:55:58] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-06 10:55:58] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-06 10:55:58] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-06 10:55:58] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-4F70C90D-FAFB-45AE-93E5-6040BAFC1B56
[2024-06-06 10:56:19] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-4F70C90D-FAFB-45AE-93E5-6040BAFC1B56 directory to /tmp/wazuh-qa/i-048bd023e60a45e28
[2024-06-06 10:56:19] [INFO] ALLOCATOR: Instance i-048bd023e60a45e28 created.
[2024-06-06 10:56:20] [INFO] ALLOCATOR: Instance i-048bd023e60a45e28 started.
[2024-06-06 10:56:20] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/i-048bd023e60a45e28/inventory.yaml
[2024-06-06 10:56:20] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/i-048bd023e60a45e28/track.yaml
[2024-06-06 10:56:21] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 54.92.204.67
[2024-06-06 10:56:52] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-06 10:56:52] [INFO] ALLOCATOR: Instance i-048bd023e60a45e28 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-048bd023e60a45e28/inventory.yaml
ansible_connection: ssh
ansible_host: ec2-54-92-204-67.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/i-048bd023e60a45e28/qa-5464-debian-11-key-9259
ansible_user: admin
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -o StrictHostKeyChecking=no -i /tmp/wazuh-qa/i-048bd023e60a45e28/qa-5464-debian-11-key-9259 -p 2200 admin@ec2-54-92-204-67.compute-1.amazonaws.com
Warning: Permanently added '[ec2-54-92-204-67.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Linux ip-172-31-33-47 5.10.0-25-cloud-amd64 #1 SMP Debian 5.10.191-1 (2023-08-16) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
admin@ip-172-31-33-47:~$ df -h
Filesystem       Size  Used Avail Use% Mounted on
udev             1.9G     0  1.9G   0% /dev
tmpfs            389M  372K  389M   1% /run
/dev/nvme0n1p1    20G  741M   18G   4% /
tmpfs            1.9G     0  1.9G   0% /dev/shm
tmpfs            5.0M     0  5.0M   0% /run/lock
/dev/nvme0n1p15  124M   11M  114M   9% /boot/efi
tmpfs            389M     0  389M   0% /run/user/1000
admin@ip-172-31-33-47:~$ exit
logout
Connection to ec2-54-92-204-67.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-048bd023e60a45e28/track.yaml 
[2024-06-06 11:07:09] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-048bd023e60a45e28/track.yaml
[2024-06-06 11:07:10] [DEBUG] ALLOCATOR: Deleting credentials: qa-5464-debian-11-key-9259
[2024-06-06 11:08:12] [INFO] ALLOCATOR: Instance i-048bd023e60a45e28 deleted.
```
![Screenshot_20240606_110658](https://github.com/wazuh/wazuh-qa/assets/64099752/ca9708fa-d8fc-47b2-aa8d-3d781ca43656)

</details>

### Debian 12

<details>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action=create --provider=aws --size=medium --label-issue https://github.com/wazuh/wazuh-qa/issues/5464 --label-termination-date 1d --label-team devops --composite-name linux-debian-12-amd64
[2024-06-06 11:08:19] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-06 11:08:20] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-06 11:08:20] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-06 11:08:20] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-8E56D8F7-CE6E-4A35-AF90-4AC5CB9F40CA
[2024-06-06 11:08:40] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-8E56D8F7-CE6E-4A35-AF90-4AC5CB9F40CA directory to /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c
[2024-06-06 11:08:40] [INFO] ALLOCATOR: Instance i-0fc6d6d1c0b748e5c created.
[2024-06-06 11:08:41] [INFO] ALLOCATOR: Instance i-0fc6d6d1c0b748e5c started.
[2024-06-06 11:08:42] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c/inventory.yaml
[2024-06-06 11:08:42] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c/track.yaml
[2024-06-06 11:08:42] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 3.236.142.232
[2024-06-06 11:09:13] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-06 11:09:13] [INFO] ALLOCATOR: Instance i-0fc6d6d1c0b748e5c created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c/inventory.yaml
ansible_connection: ssh
ansible_host: ec2-3-236-142-232.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c/qa-5464-debian-12-key-8351
ansible_user: admin
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -o StrictHostKeyChecking=no -i /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c/qa-5464-debian-12-key-8351 -p 2200 admin@ec2-3-236-142-232.compute-1.amazonaws.com
Warning: Permanently added '[ec2-3-236-142-232.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Linux ip-172-31-64-207 6.1.0-13-cloud-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.55-1 (2023-09-29) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
admin@ip-172-31-64-207:~$ df -h
Filesystem       Size  Used Avail Use% Mounted on
udev             1.9G     0  1.9G   0% /dev
tmpfs            389M  460K  388M   1% /run
/dev/nvme0n1p1    20G  838M   18G   5% /
tmpfs            1.9G     0  1.9G   0% /dev/shm
tmpfs            5.0M     0  5.0M   0% /run/lock
/dev/nvme0n1p15  124M   12M  113M  10% /boot/efi
tmpfs            389M     0  389M   0% /run/user/1000
admin@ip-172-31-64-207:~$ exit
logout
Connection to ec2-3-236-142-232.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c/track.yaml 
[2024-06-06 11:11:51] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-0fc6d6d1c0b748e5c/track.yaml
[2024-06-06 11:11:52] [DEBUG] ALLOCATOR: Deleting credentials: qa-5464-debian-12-key-8351
[2024-06-06 11:12:24] [INFO] ALLOCATOR: Instance i-0fc6d6d1c0b748e5c deleted.
```
![Screenshot_20240606_111139](https://github.com/wazuh/wazuh-qa/assets/64099752/f268f472-bed1-478d-95f0-d60b5d801cc1)

</details>

### Amazon Linux 2

<details>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action=create --provider=aws --size=medium --label-issue https://github.com/wazuh/wazuh-qa/issues/5464 --label-termination-date 1d --label-team devops --composite-name linux-amazon-2-amd64
[2024-06-06 11:12:41] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-06 11:12:42] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-06 11:12:42] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-06 11:12:42] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-379BE773-5735-4876-9D6E-C506289092D6
[2024-06-06 11:13:02] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-379BE773-5735-4876-9D6E-C506289092D6 directory to /tmp/wazuh-qa/i-00b3de37d72d5187b
[2024-06-06 11:13:02] [INFO] ALLOCATOR: Instance i-00b3de37d72d5187b created.
[2024-06-06 11:13:03] [INFO] ALLOCATOR: Instance i-00b3de37d72d5187b started.
[2024-06-06 11:13:04] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/i-00b3de37d72d5187b/inventory.yaml
[2024-06-06 11:13:04] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/i-00b3de37d72d5187b/track.yaml
[2024-06-06 11:13:04] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 44.210.95.85
[2024-06-06 11:13:34] [WARNING] ALLOCATOR: Error on attempt 2 of 30: [Errno None] Unable to connect to port 2200 on 44.210.95.85
[2024-06-06 11:14:06] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-06 11:14:06] [INFO] ALLOCATOR: Instance i-00b3de37d72d5187b created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-00b3de37d72d5187b/inventory.yaml
ansible_connection: ssh
ansible_host: ec2-44-210-95-85.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/i-00b3de37d72d5187b/qa-5464-amazon-2-key-4856
ansible_user: ec2-user
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -o StrictHostKeyChecking=no -p 2200 -i /tmp/wazuh-qa/i-00b3de37d72d5187b/qa-5464-amazon-2-key-4856 ec2-user@ec2-44-210-95-85.compute-1.amazonaws.com
Warning: Permanently added '[ec2-44-210-95-85.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
   ,     #_
   ~\_  ####_        Amazon Linux 2
  ~~  \_#####\
  ~~     \###|       AL2 End of Life is 2025-06-30.
  ~~       \#/ ___
   ~~       V~' '->
    ~~~         /    A newer version of Amazon Linux is available!
      ~~._.   _/
         _/ _/       Amazon Linux 2023, GA and supported until 2028-03-15.
       _/m/'           https://aws.amazon.com/linux/amazon-linux-2023/

29 package(s) needed for security, out of 50 available
Run "sudo yum update" to apply all updates.
[ec2-user@ip-172-31-78-118 ~]$ df -h
Filesystem      Size  Used Avail Use% Mounted on
devtmpfs        1,9G     0  1,9G   0% /dev
tmpfs           1,9G     0  1,9G   0% /dev/shm
tmpfs           1,9G  404K  1,9G   1% /run
tmpfs           1,9G     0  1,9G   0% /sys/fs/cgroup
/dev/nvme0n1p1   20G  1,9G   19G  10% /
tmpfs           387M     0  387M   0% /run/user/1000
[ec2-user@ip-172-31-78-118 ~]$ exit
logout
Connection to ec2-44-210-95-85.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-00b3de37d72d5187b/track.yaml 
[2024-06-06 11:15:10] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-00b3de37d72d5187b/track.yaml
[2024-06-06 11:15:11] [DEBUG] ALLOCATOR: Deleting credentials: qa-5464-amazon-2-key-4856
[2024-06-06 11:15:43] [INFO] ALLOCATOR: Instance i-00b3de37d72d5187b deleted.
```
![Screenshot_20240606_111457](https://github.com/wazuh/wazuh-qa/assets/64099752/3158b8bd-9fe9-4662-aeb1-ed150a4166cb)

</details>

### Ubuntu 22.04

<details>

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action=create --provider=aws --size=medium --label-issue https://github.com/wazuh/wazuh-qa/issues/5464 --label-termination-date 1d --label-team devops --composite-name linux-ubuntu-22.04-amd64
[2024-06-06 11:15:54] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-06 11:15:55] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-06 11:15:55] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-06 11:15:55] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-3E993CB2-91A3-48DE-840B-FB6538C514A5
[2024-06-06 11:16:15] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-3E993CB2-91A3-48DE-840B-FB6538C514A5 directory to /tmp/wazuh-qa/i-02a1b92174cd0c0dd
[2024-06-06 11:16:15] [INFO] ALLOCATOR: Instance i-02a1b92174cd0c0dd created.
[2024-06-06 11:16:17] [INFO] ALLOCATOR: Instance i-02a1b92174cd0c0dd started.
[2024-06-06 11:16:17] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/i-02a1b92174cd0c0dd/inventory.yaml
[2024-06-06 11:16:17] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/i-02a1b92174cd0c0dd/track.yaml
[2024-06-06 11:16:17] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 44.192.75.203
[2024-06-06 11:16:49] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-06 11:16:49] [INFO] ALLOCATOR: Instance i-02a1b92174cd0c0dd created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/i-02a1b92174cd0c0dd/inventory.yaml
ansible_connection: ssh
ansible_host: ec2-44-192-75-203.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/i-02a1b92174cd0c0dd/qa-5464-ubuntu-22.04-key-5539
ansible_user: ubuntu
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /tmp/wazuh-qa/i-02a1b92174cd0c0dd/qa-5464-ubuntu-22.04-key-5539 -o StrictHostKeyChecking=no -p 2200 ubuntu@ec2-44-192-75-203.compute-1.amazonaws.com
Warning: Permanently added '[ec2-44-192-75-203.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Welcome to Ubuntu 22.04.2 LTS (GNU/Linux 5.19.0-1025-aws x86_64)

 * Documentation:  https://help.ubuntu.com
 * Management:     https://landscape.canonical.com
 * Support:        https://ubuntu.com/advantage

  System information as of Thu Jun  6 14:16:49 UTC 2024

  System load:  0.82470703125     Processes:             109
  Usage of /:   8.1% of 19.20GB   Users logged in:       0
  Memory usage: 6%                IPv4 address for ens5: 172.31.76.25
  Swap usage:   0%


Expanded Security Maintenance for Applications is not enabled.

0 updates can be applied immediately.

Enable ESM Apps to receive additional future security updates.
See https://ubuntu.com/esm or run: sudo pro status


The list of available updates is more than a week old.
To check for new updates run: sudo apt update

To run a command as administrator (user "root"), use "sudo <command>".
See "man sudo_root" for details.

ubuntu@ip-172-31-76-25:~$ df -h
Filesystem       Size  Used Avail Use% Mounted on
/dev/root         20G  1.6G   18G   9% /
tmpfs            1.9G     0  1.9G   0% /dev/shm
tmpfs            776M  820K  775M   1% /run
tmpfs            5.0M     0  5.0M   0% /run/lock
/dev/nvme0n1p15  105M  6.1M   99M   6% /boot/efi
tmpfs            388M  4.0K  388M   1% /run/user/1000
ubuntu@ip-172-31-76-25:~$ exit
logout
Connection to ec2-44-192-75-203.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/i-02a1b92174cd0c0dd/track.yaml 
[2024-06-06 11:17:47] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/i-02a1b92174cd0c0dd/track.yaml
[2024-06-06 11:17:48] [DEBUG] ALLOCATOR: Deleting credentials: qa-5464-ubuntu-22.04-key-5539
[2024-06-06 11:19:06] [INFO] ALLOCATOR: Instance i-02a1b92174cd0c0dd deleted.
```
![Screenshot_20240606_111736](https://github.com/wazuh/wazuh-qa/assets/64099752/90aa6d00-048f-426f-97f2-738c0e43aaef)

</details>