### PR TITLE
Fix unstable cluster reliability tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 - Add an IT to check that the agent erases its wazuh-agent.state file ([#4716](https://github.com/wazuh/wazuh-qa/pull/4716)) \- (Core)
 - Fix manager_agent system tests environment ([#4808](https://github.com/wazuh/wazuh-qa/pull/4808)) \- (Framework)
 - Fixed agent_simulator response for active-response configuration commands. ([#4895](https://github.com/wazuh/wazuh-qa/pull/4895)) \- (Framework)
+- Fixed stability in cluster reliability tests. ([#5448](https://github.com/wazuh/wazuh-qa/pull/5448)) \- (Framework)
 
 ## [4.8.0] - TBD
 

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
@@ -10,7 +10,7 @@ from os.path import join
 from datetime import datetime, timedelta
 from dateutil import parser
 
-DATETIME_FORMAT = '%Y/%m/%d %H:%M:%S'
+DATETIME_FORMAT = '%Y/%m/%d %H:%M'
 SIGTERM_PATTERN = rb'SIGNAL \[\(15\)-\(SIGTERM\)\]'
 
 disconnected_nodes = []
@@ -66,12 +66,11 @@ def test_cluster_connection(artifacts_path):
             )
             if finds:
                 # Search for SIGTERM in the worker log
-                end_log_timestamp = re.search(rb'(\d{4}\/\d{2}\/\d{2} \d{2}\:\d{2}\:\d{2})', finds.group()).group()
-                start_datetime = parser.parse(end_log_timestamp.decode()) - timedelta(seconds=10)
+                end_log_timestamp = re.search(rb'(\d{4}\/\d{2}\/\d{2} \d{2}\:\d{2})', finds.group()).group()
+                start_datetime = parser.parse(end_log_timestamp.decode()) - timedelta(minutes=1)
                 start_log_timestamp = start_datetime.strftime(DATETIME_FORMAT)
 
                 start_log = re.search(fr'{start_log_timestamp}.*'.encode(), s)
-
                 worker_sigterm = re.search(SIGTERM_PATTERN, s[start_log.start():finds.start()])
 
                 if not worker_sigterm:

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
@@ -39,8 +39,15 @@ def test_cluster_connection(artifacts_path):
                             f'{node_name.search(log_file)[1]}')
 
             # Search if there are any connection attempts after the message found above.
-            if re.search(rb'^.*Could not connect to master. Trying.*$|^.*Successfully connected to master.*$',
-                         s[conn.end():], flags=re.MULTILINE):
+            if re.search(
+                rb'^.*Could not connect to master. Trying.*$|^.*Successfully connected to master.*$',
+                s[conn.end():],
+                flags=re.MULTILINE
+            ) and not re.search(
+                rb'^.*The master closed the connection.*$',
+                s[conn.end():],
+                flags=re.MULTILINE
+            ):
                 disconnected_nodes.append(node_name.search(log_file)[1])
 
     if disconnected_nodes:

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
@@ -7,7 +7,7 @@ import pytest
 from glob import glob
 from mmap import mmap, ACCESS_READ
 from os.path import join
-from datetime import datetime, timedelta
+from datetime import timedelta
 from dateutil import parser
 
 DATETIME_FORMAT = '%Y/%m/%d %H:%M'
@@ -18,13 +18,13 @@ node_name = re.compile(r'.*/(master|worker_[\d]+)/logs/cluster.log')
 
 
 def get_master_mmap(artifacts_path):
-    """Read the master cluster log and retunr a mmap with the content.
+    """Read the master cluster log and return a mmap with the content.
 
     Args:
         artifacts_path (str): Path where folders with cluster information can be found.
 
     Returns:
-        mmap: with the master logs.
+        mmap (mmap): A mmap object with the master logs.
     """
     with open(join(artifacts_path, 'master', 'logs', 'cluster.log')) as master_log:
         return mmap(master_log.fileno(), 0, access=ACCESS_READ)

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
@@ -7,9 +7,27 @@ import pytest
 from glob import glob
 from mmap import mmap, ACCESS_READ
 from os.path import join
+from datetime import datetime, timedelta
+from dateutil import parser
+
+DATETIME_FORMAT = '%Y/%m/%d %H:%M:%S'
+SIGTERM_PATTERN = rb'SIGNAL \[\(15\)-\(SIGTERM\)\]'
 
 disconnected_nodes = []
 node_name = re.compile(r'.*/(master|worker_[\d]+)/logs/cluster.log')
+
+
+def get_master_mmap(artifacts_path):
+    """Read the master cluster log and retunr a mmap with the content.
+
+    Args:
+        artifacts_path (str): Path where folders with cluster information can be found.
+
+    Returns:
+        mmap: with the master logs.
+    """
+    with open(join(artifacts_path, 'master', 'logs', 'cluster.log')) as master_log:
+        return mmap(master_log.fileno(), 0, access=ACCESS_READ)
 
 
 def test_cluster_connection(artifacts_path):
@@ -29,6 +47,8 @@ def test_cluster_connection(artifacts_path):
     if len(cluster_log_files) == 0:
         pytest.fail(f'No files found inside {artifacts_path}.')
 
+    master_mmap = get_master_mmap(artifacts_path=artifacts_path)
+
     for log_file in cluster_log_files:
         with open(log_file) as f:
             s = mmap(f.fileno(), 0, access=ACCESS_READ)
@@ -39,16 +59,28 @@ def test_cluster_connection(artifacts_path):
                             f'{node_name.search(log_file)[1]}')
 
             # Search if there are any connection attempts after the message found above.
-            if re.search(
+            finds = re.search(
                 rb'^.*Could not connect to master. Trying.*$|^.*Successfully connected to master.*$',
                 s[conn.end():],
                 flags=re.MULTILINE
-            ) and not re.search(
-                rb'^.*The master closed the connection.*$',
-                s[conn.end():],
-                flags=re.MULTILINE
-            ):
-                disconnected_nodes.append(node_name.search(log_file)[1])
+            )
+            if finds:
+                # Search for SIGTERM in the worker log
+                end_log_timestamp = re.search(rb'(\d{4}\/\d{2}\/\d{2} \d{2}\:\d{2}\:\d{2})', finds.group()).group()
+                start_datetime = parser.parse(end_log_timestamp.decode()) - timedelta(seconds=10)
+                start_log_timestamp = start_datetime.strftime(DATETIME_FORMAT)
+
+                start_log = re.search(fr'{start_log_timestamp}.*'.encode(), s)
+
+                worker_sigterm = re.search(SIGTERM_PATTERN, s[start_log.start():finds.start()])
+
+                if not worker_sigterm:
+                    # Search for SIGTERM in the master log
+                    master_start_log = re.search(fr'{start_log_timestamp}.*'.encode(), master_mmap)
+                    master_sigterm = re.search(SIGTERM_PATTERN, master_mmap[master_start_log.start():])
+
+                    if not master_sigterm:
+                        disconnected_nodes.append(node_name.search(log_file)[1])
 
     if disconnected_nodes:
         pytest.fail(f'The following nodes disconnected from master at any point:\n- ' + '\n- '.join(disconnected_nodes))

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_worker_logs_order/data/Integrity_sync.yml
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_worker_logs_order/data/Integrity_sync.yml
@@ -20,15 +20,9 @@
   tag: 'Updating local files: Start.*'
 - log_id: log13
   parent: log12
-  tag: 'Received [0-9]* missing files to update from master.'
+  tag: 'Updating local files: End.'
 - log_id: log14
   parent: log13
-  tag: 'Received [0-9]* shared files to update from master.*'
-- log_id: log15
-  parent: log14
-  tag: 'Updating local files: End.'
-- log_id: log16
-  parent: log15
   tag: 'Finished in .*'
 
 # No sync needed.


### PR DESCRIPTION
# Description

This PR closes #4385. It adds more intelligence to tests, considering when the master closes the connection with the workers, to get these working correctly.

Using the artifacts from the last [workload benchmarks metrics](https://github.com/wazuh/wazuh/issues/23712) we got these results:

[artifacts.zip](https://github.com/wazuh/wazuh-qa/files/15502137/542.zip)

```console
(wqa) ➜  wazuh-qa git:(fix/4385-unstable-realiability-tests) pytest -s --artifacts_path=/home/nstefani/Downloads/542 tests/reliability/test_cluster/test_cluster_logs
================================================================================================ test session starts ================================================================================================
platform linux -- Python 3.9.16, pytest-7.1.2, pluggy-0.13.1
rootdir: /home/nstefani/git/wazuh-qa/tests, configfile: pytest.ini
plugins: html-3.1.1, testinfra-5.0.0, metadata-2.0.4
collected 6 items

tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py .
tests/reliability/test_cluster/test_cluster_logs/test_cluster_error_logs/test_cluster_error_logs.py .
tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py .
tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py .
tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py .
tests/reliability/test_cluster/test_cluster_logs/test_cluster_worker_logs_order/test_cluster_worker_logs_order.py .

=========================================================================================== 6 passed in 175.91s (0:02:55) ===========================================================================================
```