### PR TITLE
The rollback method is improved in the case of not being able to obtain the status of the instance correctly

### DIFF
--- a/deployability/modules/allocation/vagrant/instance.py
+++ b/deployability/modules/allocation/vagrant/instance.py
@@ -103,7 +103,7 @@ class VagrantInstance(Instance):
                             Skipping deletion.")
             return
         self.__run_vagrant_command(['destroy', '-f'])
-        if self.host_instance_dir:
+        if str(self.host_identifier) == "macstadium":
             self.__cleanup_remote_host()
 
     def status(self) -> str:
@@ -268,10 +268,9 @@ class VagrantInstance(Instance):
         Returns:
             None
         """
-        if str(self.host_identifier) == "macstadium":
-            logger.debug(f"Deleting remote directory {self.host_instance_dir}")
-            VagrantUtils.remote_command(f"sudo rm -rf {self.host_instance_dir}", self.remote_host_parameters)
-            if self.virtualizer == 'parallels':
-                logger.debug(f"Killing remote process on port {self.ssh_port}")
-                proccess = VagrantUtils.remote_command(f"sudo lsof -Pi :{self.ssh_port} -sTCP:LISTEN -t", self.remote_host_parameters)
-                VagrantUtils.remote_command(f"sudo kill -9 {proccess}", self.remote_host_parameters)
+        logger.debug(f"Deleting remote directory {self.host_instance_dir}")
+        VagrantUtils.remote_command(f"sudo rm -rf {self.host_instance_dir}", self.remote_host_parameters)
+        if self.virtualizer == 'parallels':
+            logger.debug(f"Killing remote process on port {self.ssh_port}")
+            proccess = VagrantUtils.remote_command(f"sudo lsof -Pi :{self.ssh_port} -sTCP:LISTEN -t", self.remote_host_parameters)
+            VagrantUtils.remote_command(f"sudo kill -9 {proccess}", self.remote_host_parameters)

--- a/deployability/modules/allocation/vagrant/instance.py
+++ b/deployability/modules/allocation/vagrant/instance.py
@@ -122,15 +122,15 @@ class VagrantInstance(Instance):
                 output = VagrantUtils.remote_command(f"sudo test -d {self.host_instance_dir} && echo 'Directory exists' || echo 'Directory does not exist'", self.remote_host_parameters)
                 if 'Directory exists' in output:
                     if VagrantUtils.remote_command(f"sudo /usr/local/bin/prlctl list -a | grep {self.identifier}", self.remote_host_parameters):
-                        logger.warning(f"The instance was found, it will be deleted. The creation of the instance must be restarted again.")
+                        logger.warning(f"The instance was found, it will be deleted. The creation of the instance must be retried..")
                         self.__run_vagrant_command(['destroy', '-f'])
                         self.__cleanup_remote_host()
-                        raise ValueError(f"Cannot obtain the status of the instance {self.identifier}, the creation of the instance must be restarted again.")
+                        raise ValueError(f"Cannot obtain the status of the instance {self.identifier}, the creation of the instance must be retried..")
                     else:
                         VagrantUtils.remote_command(f"sudo rm -rf {self.host_instance_dir}", self.remote_host_parameters)
-                        raise ValueError(f"Instance {self.identifier} is not running, remote instance dir {self.host_instance_dir} was removed.")
+                        raise ValueError(f"Instance {self.identifier} is not running, remote instance dir {self.host_instance_dir} was removed. The creation of the instance must be retried.")
                 else:
-                    raise ValueError(f"Instance {self.host_instance_dir} not found.")
+                    raise ValueError(f"Instance {self.host_instance_dir} not found. The creation of the instance must be retried.")
         else:
             return vagrant_status
 

--- a/deployability/modules/allocation/vagrant/instance.py
+++ b/deployability/modules/allocation/vagrant/instance.py
@@ -122,10 +122,10 @@ class VagrantInstance(Instance):
                 output = VagrantUtils.remote_command(f"sudo test -d {self.host_instance_dir} && echo 'Directory exists' || echo 'Directory does not exist'", self.remote_host_parameters)
                 if 'Directory exists' in output:
                     if VagrantUtils.remote_command(f"sudo /usr/local/bin/prlctl list -a | grep {self.identifier}", self.remote_host_parameters):
-                        logger.warning(f"The instance was found, it will be deleted. The creation of the instance must be retried..")
+                        logger.warning(f"The instance was found, it will be deleted. The creation of the instance must be retried.")
                         self.__run_vagrant_command(['destroy', '-f'])
                         self.__cleanup_remote_host()
-                        raise ValueError(f"Cannot obtain the status of the instance {self.identifier}, the creation of the instance must be retried..")
+                        raise ValueError(f"Cannot obtain the status of the instance {self.identifier}, the creation of the instance must be retried.")
                     else:
                         VagrantUtils.remote_command(f"sudo rm -rf {self.host_instance_dir}", self.remote_host_parameters)
                         raise ValueError(f"Instance {self.identifier} is not running, remote instance dir {self.host_instance_dir} was removed. The creation of the instance must be retried.")


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-qa/issues/5478

## Description

This PR aims to improve the method of getting vagrant status, in some queries the result is None, which leads to managing a rollback of this instance and then having to re-execute the construction of the VM.

## Tests

### macOS Intel parallels:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size small --instance-name cbordon-test --composite-name macos-sonoma-14-amd64
[2024-06-11 12:19:04] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-11 12:19:17] [INFO] ALLOCATOR: Using the macStadium Intel server to deploy.
[2024-06-11 12:19:17] [DEBUG] ALLOCATOR: Checking if instance directory exists on remote host
[2024-06-11 12:19:20] [DEBUG] ALLOCATOR: Creating instance directory on remote host
[2024-06-11 12:19:22] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-11 12:19:22] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-11 12:19:26] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-06-11 12:19:37] [INFO] ALLOCATOR: Instance cbordon-test-6462 created.
[2024-06-11 12:20:25] [INFO] ALLOCATOR: Instance cbordon-test-6462 started.
[2024-06-11 12:20:42] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/cbordon-test-6462/inventory.yaml
[2024-06-11 12:20:42] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/cbordon-test-6462/track.yaml
[2024-06-11 12:20:44] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-11 12:20:44] [INFO] ALLOCATOR: Instance cbordon-test-6462 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/cbordon-test-6462/track.yaml 
[2024-06-11 12:20:57] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/cbordon-test-6462/track.yaml
[2024-06-11 12:20:58] [DEBUG] ALLOCATOR: Destroying instance cbordon-test-6462
[2024-06-11 12:21:14] [DEBUG] ALLOCATOR: Deleting remote directory /Users/jenkins/testing/cbordon-test-6462
[2024-06-11 12:21:17] [DEBUG] ALLOCATOR: Killing remote process on port 43239
[2024-06-11 12:21:23] [INFO] ALLOCATOR: Instance cbordon-test-6462 deleted
```

### macOS Intel VirtualBox:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size small --instance-name cbordon-test --composite-name macos-sierra-10.12-amd64
[2024-06-11 11:39:27] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-11 11:39:40] [INFO] ALLOCATOR: Using the macStadium Intel server to deploy.
[2024-06-11 11:39:40] [DEBUG] ALLOCATOR: Checking if instance directory exists on remote host
[2024-06-11 11:39:43] [DEBUG] ALLOCATOR: Creating instance directory on remote host
[2024-06-11 11:39:45] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-11 11:39:45] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-11 11:39:52] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-06-11 11:40:03] [INFO] ALLOCATOR: Instance cbordon-test-7319 created.
[2024-06-11 11:46:23] [INFO] ALLOCATOR: Instance cbordon-test-7319 started.
[2024-06-11 11:46:33] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/cbordon-test-7319/inventory.yaml
[2024-06-11 11:46:33] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/cbordon-test-7319/track.yaml
[2024-06-11 11:46:35] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-11 11:46:35] [INFO] ALLOCATOR: Instance cbordon-test-7319 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/cbordon-test-7319/track.yaml 
[2024-06-11 11:53:35] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/cbordon-test-7319/track.yaml
[2024-06-11 11:53:37] [DEBUG] ALLOCATOR: Destroying instance cbordon-test-7319
[2024-06-11 11:53:49] [DEBUG] ALLOCATOR: Deleting remote directory /Users/jenkins/testing/cbordon-test-7319
[2024-06-11 11:53:52] [INFO] ALLOCATOR: Instance cbordon-test-7319 deleted.
```

### macOS ARM:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size small --instance-name cbordon-test --composite-name macos-sonoma-14-arm64
[2024-06-11 11:18:42] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-11 11:18:48] [INFO] ALLOCATOR: macStadium ARM server has less than 2 VMs running, deploying in this host.
[2024-06-11 11:18:48] [DEBUG] ALLOCATOR: Checking if instance directory exists on remote host
[2024-06-11 11:18:51] [DEBUG] ALLOCATOR: Creating instance directory on remote host
[2024-06-11 11:18:53] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-11 11:18:53] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-11 11:18:57] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-06-11 11:19:09] [INFO] ALLOCATOR: Instance cbordon-test-1483 created.
[2024-06-11 11:20:05] [INFO] ALLOCATOR: Instance cbordon-test-1483 started.
[2024-06-11 11:20:20] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/cbordon-test-1483/inventory.yaml
[2024-06-11 11:20:20] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/cbordon-test-1483/track.yaml
[2024-06-11 11:20:22] [INFO] ALLOCATOR: SSH connection successful.
[2024-06-11 11:20:22] [INFO] ALLOCATOR: Instance cbordon-test-1483 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/cbordon-test-1483/track.yaml 
[2024-06-11 11:35:52] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/cbordon-test-1483/track.yaml
[2024-06-11 11:35:54] [DEBUG] ALLOCATOR: Destroying instance cbordon-test-1483
[2024-06-11 11:38:25] [DEBUG] ALLOCATOR: Deleting remote directory /Users/jenkins/testing/cbordon-test-1483
[2024-06-11 11:38:28] [DEBUG] ALLOCATOR: Killing remote process on port 43222
[2024-06-11 11:38:33] [INFO] ALLOCATOR: Instance cbordon-test-1483 deleted.
```

### Forcing the error:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size small --instance-name cbordon-test --composite-name macos-sonoma-14-amd64
[2024-06-11 12:12:30] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-06-11 12:12:44] [INFO] ALLOCATOR: Using the macStadium Intel server to deploy.
[2024-06-11 12:12:44] [DEBUG] ALLOCATOR: Checking if instance directory exists on remote host
[2024-06-11 12:12:47] [DEBUG] ALLOCATOR: Creating instance directory on remote host
[2024-06-11 12:12:49] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-06-11 12:12:49] [DEBUG] ALLOCATOR: Generating new key pair
[2024-06-11 12:12:53] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-06-11 12:13:04] [INFO] ALLOCATOR: Instance cbordon-test-4461 created.
[2024-06-11 12:13:50] [INFO] ALLOCATOR: Instance cbordon-test-4461 started.
[2024-06-11 12:13:56] [ERROR] ALLOCATOR: Received None message when parsing Vagrant status
[2024-06-11 12:14:02] [WARNING] ALLOCATOR: The instance was found, it will be deleted. The creation of the instance must be restarted again.
[2024-06-11 12:14:12] [DEBUG] ALLOCATOR: Deleting remote directory /Users/jenkins/testing/cbordon-test-4461
[2024-06-11 12:14:15] [DEBUG] ALLOCATOR: Killing remote process on port None
Traceback (most recent call last):
  File "/home/cbordon/Documents/wazuh/repositorios/wazuh-qa/deployability/modules/allocation/main.py", line 39, in <module>
    main()
  File "/home/cbordon/Documents/wazuh/repositorios/wazuh-qa/deployability/modules/allocation/main.py", line 35, in main
    Allocator.run(InputPayload(**vars(parse_arguments())))
  File "/home/cbordon/Documents/wazuh/repositorios/wazuh-qa/deployability/modules/allocation/allocation.py", line 40, in run
    return cls.__create(payload)
  File "/home/cbordon/Documents/wazuh/repositorios/wazuh-qa/deployability/modules/allocation/allocation.py", line 66, in __create
    inventory = cls.__generate_inventory(instance, instance_params.composite_name)
  File "/home/cbordon/Documents/wazuh/repositorios/wazuh-qa/deployability/modules/allocation/allocation.py", line 130, in __generate_inventory
    ssh_config = instance.ssh_connection_info()
  File "/home/cbordon/Documents/wazuh/repositorios/wazuh-qa/deployability/modules/allocation/vagrant/instance.py", line 156, in ssh_connection_info
    if not 'running' in self.status():
  File "/home/cbordon/Documents/wazuh/repositorios/wazuh-qa/deployability/modules/allocation/vagrant/instance.py", line 128, in status
    raise ValueError(f"Cannot obtain the status of the instance {self.identifier}, the creation of the instance must be restarted again.")
ValueError: Cannot obtain the status of the instance cbordon-test-4461, the creation of the instance must be restarted again.
```