### PR TITLE
Unify Process Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [4.8.1] - TBD
 
+### Added
+
+- Add functionality to unify data of the binary processes with their subprocesses to plot ([#5500](https://github.com/wazuh/wazuh-qa/pull/5500)) \- (Framework)
+
 ## [4.8.0] - 12/06/2024
 
 ### Added

--- a/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
@@ -34,7 +34,7 @@ def main():
         makedirs(destination)
     dv = DataVisualizer(dataframes=options.csv_list, target=options.visualization_target,
                         compare=False, store_path=options.destination, base_name=options.name,
-                        columns_path=options.columns, unify=options.unify)
+                        columns_path=options.columns, unify_child_daemon_metrics=options.unify)
     dv.plot()
 
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
@@ -21,7 +21,7 @@ def get_script_arguments():
     parser.add_argument('-c', '--columns', dest='columns', default=None,
                         help=f'Path to Json with Columns to Plot. Default {None}.')
     parser.add_argument('-u', '--unify', dest='unify', default=False,
-                        help=f'Unify process values. Default {False}.')  
+                        help=f'Unify process values. Default {False}.')
 
     return parser.parse_args()
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
@@ -21,7 +21,7 @@ def get_script_arguments():
     parser.add_argument('-c', '--columns', dest='columns', default=None,
                         help=f'Path to Json with Columns to Plot. Default {None}.')
     parser.add_argument('-u', '--unify', dest='unify', default=False,
-                        help=f'Unify process values. Default {False}.')
+                        help=f'Unify data of the binary processes with their subprocesses to plot. Default {False}.')
 
     return parser.parse_args()
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
@@ -20,8 +20,8 @@ def get_script_arguments():
                         help=f'Base name for the images. Default {None}.')
     parser.add_argument('-c', '--columns', dest='columns', default=None,
                         help=f'Path to Json with Columns to Plot. Default {None}.')
-    parser.add_argument('-u', '--unify', dest='unify', default=False,
-                        help=f'Unify data of the binary processes with their subprocesses to plot. Default {False}.')
+    parser.add_argument('-u', '--unify', dest='unify', action='store_true',
+                        help=f'Unify data of the binary processes with their subprocesses to plot.')
 
     return parser.parse_args()
 

--- a/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
+++ b/deps/wazuh_testing/wazuh_testing/scripts/data_visualizations.py
@@ -20,6 +20,8 @@ def get_script_arguments():
                         help=f'Base name for the images. Default {None}.')
     parser.add_argument('-c', '--columns', dest='columns', default=None,
                         help=f'Path to Json with Columns to Plot. Default {None}.')
+    parser.add_argument('-u', '--unify', dest='unify', default=False,
+                        help=f'Unify process values. Default {False}.')  
 
     return parser.parse_args()
 
@@ -32,7 +34,7 @@ def main():
         makedirs(destination)
     dv = DataVisualizer(dataframes=options.csv_list, target=options.visualization_target,
                         compare=False, store_path=options.destination, base_name=options.name,
-                        columns_path=options.columns)
+                        columns_path=options.columns, unify=options.unify)
     dv.plot()
 
 

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -48,7 +48,7 @@ class DataVisualizer:
         if target in ['binary', 'analysis', 'remote', 'agent', 'logcollector', 'wazuhdb']:
             self.columns_to_plot = self._load_columns_to_plot(columns_path)
 
-        if unify:
+        if unify.lower() in ["true"]:
             self._unify_dataframes()
 
     @staticmethod

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -93,14 +93,19 @@ class DataVisualizer:
 
     def _unify_dataframes(self):
         """Unify dataframe values."""
+        daemons_list = [daemon_name for daemon_name in self._get_daemons() if "child" not in daemon_name]
+
+        for daemon_name in daemons_list:
+            self.dataframe.loc[self.dataframe['Daemon'].str.contains(daemon_name, na=False), 'Daemon'] = daemon_name
+
         df_row = self.dataframe.iloc[0]
-        df_names = [df_row['Daemon'], df_row['Version'], df_row['PID']]
-        columns_to_drop = ['Daemon', 'Version', 'PID']
+        df_names = [df_row['Version'], df_row['PID']]
+        columns_to_drop = ['Timestamp', 'Daemon', 'Version', 'PID']
         columns_to_sum = self.dataframe.columns.drop(columns_to_drop)
-        self.dataframe = self.dataframe.groupby('Timestamp')[columns_to_sum].sum().reset_index(drop=False)
+        self.dataframe = self.dataframe.groupby(['Timestamp', 'Daemon'])[columns_to_sum].sum().reset_index(drop=False)
 
         for index, value in enumerate(df_names):
-            self.dataframe.insert(index, columns_to_drop[index], value)
+            self.dataframe.insert(index+2, columns_to_drop[index+2], value)
 
     def _set_x_ticks_interval(self, ax):
         """Set the number of labels that will appear in the X axis and their format.

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -93,19 +93,21 @@ class DataVisualizer:
 
     def _unify_dataframes(self):
         """Unify dataframe values."""
+        pids = self.dataframe[['Daemon', 'PID']].drop_duplicates()
+        versions = self.dataframe[['Daemon', 'Version']].drop_duplicates()
+
         daemons_list = [daemon_name for daemon_name in self._get_daemons() if "child" not in daemon_name]
 
         for daemon_name in daemons_list:
             self.dataframe.loc[self.dataframe['Daemon'].str.contains(daemon_name, na=False), 'Daemon'] = daemon_name
 
-        df_row = self.dataframe.iloc[0]
-        df_names = [df_row['Version'], df_row['PID']]
         columns_to_drop = ['Timestamp', 'Daemon', 'Version', 'PID']
         columns_to_sum = self.dataframe.columns.drop(columns_to_drop)
+
         self.dataframe = self.dataframe.groupby(['Timestamp', 'Daemon'])[columns_to_sum].sum().reset_index(drop=False)
 
-        for index, value in enumerate(df_names):
-            self.dataframe.insert(index+2, columns_to_drop[index+2], value)
+        self.dataframe = self.dataframe.merge(pids[['Daemon', 'PID']], on='Daemon', how='left')
+        self.dataframe = self.dataframe.merge(versions[['Daemon', 'Version']], on='Daemon', how='left')
 
     def _set_x_ticks_interval(self, ax):
         """Set the number of labels that will appear in the X axis and their format.

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -32,7 +32,7 @@ class DataVisualizer:
         base_name (str, optional): base name used to store the images.
     """
     def __init__(self, dataframes, target, compare=False, store_path=gettempdir(), x_ticks_granularity='minutes',
-                 x_ticks_interval=1, base_name=None, columns_path=None, unify=False):
+                 x_ticks_interval=1, base_name=None, columns_path=None, unify_child_daemon_metrics=False):
         self.dataframes_paths = dataframes
         self.dataframe = None
         self.compare = compare
@@ -48,7 +48,7 @@ class DataVisualizer:
         if target in ['binary', 'analysis', 'remote', 'agent', 'logcollector', 'wazuhdb']:
             self.columns_to_plot = self._load_columns_to_plot(columns_path)
 
-        if unify.lower() in ["true"]:
+        if unify_child_daemon_metrics.lower() in ["true"]:
             self._unify_dataframes()
 
     @staticmethod

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -48,7 +48,8 @@ class DataVisualizer:
         if target in ['binary', 'analysis', 'remote', 'agent', 'logcollector', 'wazuhdb']:
             self.columns_to_plot = self._load_columns_to_plot(columns_path)
 
-        if unify_child_daemon_metrics.lower() in ["true"]:
+        if unify_child_daemon_metrics.lower() in ["true"] and target in ['binary']:
+            self.dataframe = self.dataframe.reset_index(drop=False)
             self._unify_dataframes()
 
     @staticmethod

--- a/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/performance/visualization.py
@@ -4,6 +4,7 @@ from tempfile import gettempdir
 from matplotlib.ticker import LinearLocator
 
 import json
+import logging
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -48,9 +49,12 @@ class DataVisualizer:
         if target in ['binary', 'analysis', 'remote', 'agent', 'logcollector', 'wazuhdb']:
             self.columns_to_plot = self._load_columns_to_plot(columns_path)
 
-        if unify_child_daemon_metrics.lower() in ["true"] and target in ['binary']:
-            self.dataframe = self.dataframe.reset_index(drop=False)
-            self._unify_dataframes()
+        if unify_child_daemon_metrics:
+            if target == 'binary':
+                self.dataframe = self.dataframe.reset_index(drop=False)
+                self._unify_dataframes()
+            else:
+                logging.warning("Enabled unify is only available for binary data. Ignoring")
 
     @staticmethod
     def _color_palette(size):
@@ -92,7 +96,8 @@ class DataVisualizer:
                 self.dataframe = pd.concat([self.dataframe, new_csv])
 
     def _unify_dataframes(self):
-        """Unify dataframe values."""
+        """Unify the data of each process with their respective sub-processes.
+        """
         pids = self.dataframe[['Daemon', 'PID']].drop_duplicates()
         versions = self.dataframe[['Daemon', 'Version']].drop_duplicates()
 


### PR DESCRIPTION
# Description

| Related Issue |
| --- |
| https://github.com/wazuh/wazuh-qa/issues/5479 |

Create a method in the `DataVisualizer` class that allows to unify the data obtained from the processes and subprocesses so that, when a plot is generated, the data of processes and subprocesses do not appear but all the data unified in a single process.

---

## Testing performed

The tests can be performed locally using the `DataVisualizer` or using the [CLUSTER-Workload_benchmarks_metrics](https://ci.wazuh.info/job/CLUSTER-Workload_benchmarks_metrics/) pipeline with the simplest possible tests. It is only necessary to activate the option to unify data and provide 2 or more CSV of processes (one process and one or more sub processes).

| Validation | Jenkins | Local | OS |
| --- | --- | --- | --- |
| Check plots and painting information | 🟢  | 🟢 | Ubuntu 22.04 |

- Build: https://ci.wazuh.info/view/Tests_DEV/job/CLUSTER-Workload_benchmarks_metrics_5479/2/