### PR TITLE
Force 30 minutes sleep in Vulnerability Detection initial scan to avoid indexer abuse control 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [4.8.1] - TBD
 
+### Changed
+
+- Fix test_consistency_initial_scans by adding a 30-minute wait before collecting vulnerabilities. ([#5507](https://github.com/wazuh/wazuh-qa/pull/5507)) \- (Tests)
+
 ## [4.8.0] - 12/06/2024
 
 ### Added

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -320,13 +320,11 @@ class TestInitialScans:
                 "Syscollector scan not started in any agent. Check agent logs for more information"
             )
 
-
         logging.critical("Waiting 30 minutes to avoid Indexer abuseControl.")
         time.sleep(MINIMUM_TIMEOUT_RESCAN)
 
         logging.critical("Waiting until agent all agents have been scanned.")
         time.sleep(TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN * len(AGENTS_SCANNED_FIRST_SCAN))
-
 
         logging.critical("Checking vulnerabilities in the index")
         vuln_by_agent_index = get_vulnerabilities_from_states_by_agent(

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -320,11 +320,13 @@ class TestInitialScans:
                 "Syscollector scan not started in any agent. Check agent logs for more information"
             )
 
-        logging.critical("Waiting until agent all agents have been scanned.")
 
-        time_to_wait = max(TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN * len(AGENTS_SCANNED_FIRST_SCAN),
-                           MINIMUM_TIMEOUT_RESCAN)
-        time.sleep(time_to_wait)
+        logging.critical("Waiting 30 minutes to avoid Indexer abuseControl.")
+        time.sleep(MINIMUM_TIMEOUT_RESCAN)
+
+        logging.critical("Waiting until agent all agents have been scanned.")
+        time.sleep(TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN * len(AGENTS_SCANNED_FIRST_SCAN))
+
 
         logging.critical("Checking vulnerabilities in the index")
         vuln_by_agent_index = get_vulnerabilities_from_states_by_agent(

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -71,8 +71,11 @@ from wazuh_testing.end_to_end.vulnerability_detector import (TIMEOUT_PER_AGENT_V
 from wazuh_testing.end_to_end.waiters import wait_until_vd_is_updated
 from wazuh_testing.tools.system import HostManager
 
+
 pytestmark = [pytest.mark.e2e, pytest.mark.vulnerability_detector, pytest.mark.tier0]
 
+# Wazuh Indexer abuseControl timeout set to 30 minutes (1800 seconds)
+MINIMUM_TIMEOUT_RESCAN = 1800
 
 AGENTS_SCANNED_FIRST_SCAN = []
 FIRST_SCAN_TIME = None
@@ -318,7 +321,10 @@ class TestInitialScans:
             )
 
         logging.critical("Waiting until agent all agents have been scanned.")
-        time.sleep(TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN * len(AGENTS_SCANNED_FIRST_SCAN))
+
+        time_to_wait = max(TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN * len(AGENTS_SCANNED_FIRST_SCAN),
+                           MINIMUM_TIMEOUT_RESCAN)
+        time.sleep(time_to_wait)
 
         logging.critical("Checking vulnerabilities in the index")
         vuln_by_agent_index = get_vulnerabilities_from_states_by_agent(


### PR DESCRIPTION
# Description

This PR introduces a timeout to address Vulnerability Detector consistency issues caused by abuse control logic. It enforces a mandatory 30-minute delay before collecting indexed vulnerabilities.

---

## Testing performed



| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | [:green_circle:](https://ci.wazuh.info/job/Test_e2e_system/303/)  |  |         |         | Nothing to highlight |