### PR TITLE
Added RHEL 8.10 to the Allocator module

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -329,7 +329,7 @@ aws:
     zone: us-east-1
     user: ec2-user
   linux-redhat-8-amd64:
-    ami: ami-054333d53aa32850c
+    ami: ami-00d00bcb416b79a1a
     zone: us-east-1
     user: ec2-user
   linux-redhat-8-arm64:


### PR DESCRIPTION
# Description

The aim of this PR is to add the RHEL 8.10 AMI to the Allocator module.

---

## Testing performed

:green_circle: The testing of the Allocator module is here: https://github.com/wazuh/wazuh/issues/23880#issuecomment-2176590896
:green_circle: The testing of the Wazuh central components installation is here: https://github.com/wazuh/wazuh/issues/23880#issuecomment-2176603105