### PR TITLE
Fixed CentOS9 AMI in Allocator module

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -316,7 +316,7 @@ aws:
     zone: us-east-1
     user: cloud-user
   linux-centos-9-amd64:
-    ami: ami-0259c451b16b72e24
+    ami: ami-0df2a11dd1fe1f8e3
     zone: us-east-1
     user: ec2-user
   # Redhat


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->

---

Closes: https://github.com/wazuh/wazuh-qa/issues/5522
The aim of this PR is to fix the CentOS9 AMI of the Allocator module because the preivous one was not working. 

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

The performed testing is here: https://github.com/wazuh/wazuh-qa/issues/5522#issuecomment-2196564282