### PR TITLE
Updated Oracle Linux 9 AMI

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -281,7 +281,7 @@ aws:
     zone: us-east-1
     user: ec2-user
   linux-oracle-9-amd64:
-    ami: ami-01453ca80e53609e3
+    ami: ami-097ad3c47f3a500e1
     zone: us-east-1
     user: ec2-user
   # openSUSE Linux


### PR DESCRIPTION
Close https://github.com/wazuh/wazuh/issues/24142

Oracle Linux 9 AMI updated to 9.4 version

Allocation module and installation assistant test: https://github.com/wazuh/wazuh/issues/24142#issuecomment-2196650878