### PR TITLE
Updated Allocator module with Debian 12.6 OS

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -264,11 +264,11 @@ aws:
     zone: us-east-1
     user: admin
   linux-debian-12-amd64:
-    ami: ami-058bd2d568351da34
+    ami: ami-055c8118725fe3a84
     zone: us-east-1
     user: admin
   linux-debian-12-arm64:
-    ami: ami-0f58aa386a2280f35
+    ami: ami-06703877c23c4ddf1
     zone: us-east-1
     user: admin
   # Oracle Linux


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->
---
The aim of this PR is to update the Allocator module with the Debian 12.6 AMIs. 
Related: https://github.com/wazuh/wazuh/issues/24371

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

An AMI was created from the updated system, and a test with the new AMI was performed:

```console
> python3 modules/allocation/main.py --action create --provider aws --size large --composite-name linux-debian-12-amd64 --inventory-output "/tmp/dtt1-poc/debian12-new/inventory.yaml" --track-output "/tmp/dtt1-poc/debian12-new/track.yaml" --label-termination-date "1d" --label-team "devops" --label-issue "https://github.com/wazuh/wazuh/issues/24371"

[2024-07-01 16:47:38] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-01 16:47:40] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-01 16:47:40] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-01 16:47:40] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-0B8FC857-4566-4BF4-859A-164DDBA011D1
[2024-07-01 16:48:00] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-0B8FC857-4566-4BF4-859A-164DDBA011D1 directory to /tmp/wazuh-qa/i-0c990b411aa58d4d2
[2024-07-01 16:48:00] [INFO] ALLOCATOR: Instance i-0c990b411aa58d4d2 created.
[2024-07-01 16:48:02] [INFO] ALLOCATOR: Instance i-0c990b411aa58d4d2 started.
[2024-07-01 16:48:02] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/debian12-new/inventory.yaml
[2024-07-01 16:48:02] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/debian12-new/track.yaml
[2024-07-01 16:48:09] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 100.26.55.137
[2024-07-01 16:48:41] [INFO] ALLOCATOR: SSH connection successful.
[2024-07-01 16:48:41] [INFO] ALLOCATOR: Instance i-0c990b411aa58d4d2 created successfully.

> ssh -i /tmp/wazuh-qa/i-0c990b411aa58d4d2/wazuh-24371-debian-12-key-5561 admin@ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com -p2200
The authenticity of host '[ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com]:2200 ([100.26.55.137]:2200)' can't be established.
ED25519 key fingerprint is SHA256:PXJ9Rr7H17MDsolsaZOjbYJRDIcLNK0oSmuiWKWBsRI.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Linux ip-172-31-25-152 6.1.0-13-cloud-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.55-1 (2023-09-29) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Mon Jul  1 14:33:46 2024 from 79.117.226.210
admin@ip-172-31-25-152:~$ cat /etc/
Display all 139 possibilities? (y or n)
admin@ip-172-31-25-152:~$ cat /etc/debian_version 
12.6
```

Same test was performed with the Debian 12.6 ARM64 system.