### PR TITLE
Updated Allocator module with AL2023 AMIs

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -354,11 +354,11 @@ aws:
     zone: us-east-1
     user: ec2-user
   linux-amazon-2023-amd64:
-    ami: ami-067d1e60475437da2
+    ami: ami-0d4e679eb7361c9c9
     zone: us-east-1
     user: ec2-user
   linux-amazon-2023-arm64:
-    ami: ami-08b46fd32a1a5be7f
+    ami: ami-0a7fdbc9c086df09c
     zone: us-east-1
     user: ec2-user
   # Fedora


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->
---
The aim of this PR is to update the Allocator module with the AL2023 AMIs (2023.5.20240624). 
Related: https://github.com/wazuh/wazuh/issues/24373

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

An AMI was created from the updated system, and a test with the new AMI was performed:

```console
> python3 modules/allocation/main.py --action create --provider aws --size medium --composite-name linux-amazon-2023-amd64 --inventory-output "/tmp/dtt1-poc/al2023-base/inventory.yaml" --track-output "/tmp/dtt1-poc/al2023-base/track.yaml" --label-issue "https://github.com/wazuh/wazuh/issues/24371" --label-termination-date "1d" --label-team "devops"
[2024-07-01 17:22:57] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-01 17:22:58] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-01 17:22:58] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-01 17:22:58] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-8773D273-1F38-4F97-BB0C-A6B2C77AF49F
[2024-07-01 17:23:20] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-8773D273-1F38-4F97-BB0C-A6B2C77AF49F directory to /tmp/wazuh-qa/i-04ddae22e4654b970
[2024-07-01 17:23:20] [INFO] ALLOCATOR: Instance i-04ddae22e4654b970 created.
[2024-07-01 17:23:21] [INFO] ALLOCATOR: Instance i-04ddae22e4654b970 started.
[2024-07-01 17:23:21] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/al2023-base/inventory.yaml
[2024-07-01 17:23:21] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/al2023-base/track.yaml
[2024-07-01 17:23:41] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 100.28.122.50
[2024-07-01 17:24:13] [INFO] ALLOCATOR: SSH connection successful.
[2024-07-01 17:24:13] [INFO] ALLOCATOR: Instance i-04ddae22e4654b970 created successfully.

> ssh -i /tmp/wazuh-qa/i-04ddae22e4654b970/wazuh-24371-amazon-2023-key-3364 ec2-user@ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com -p2200
The authenticity of host '[ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com]:2200 ([100.28.122.50]:2200)' can't be established.
ED25519 key fingerprint is SHA256:WOTijjqCzIyN3q8MIzfEfunL+HoUCZEQVitOxhHDGOs.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
   ,     #_
   ~\_  ####_        Amazon Linux 2023
  ~~  \_#####\
  ~~     \###|
  ~~       \#/ ___   https://aws.amazon.com/linux/amazon-linux-2023
   ~~       V~' '->
    ~~~         /
      ~~._.   _/
         _/ _/
       _/m/'
Last login: Mon Jul  1 14:58:34 2024 from 79.117.226.210
[ec2-user@ip-172-31-71-40 ~]$ rpm -q system-release
system-release-2023.5.20240624-0.amzn2023.noarch
[ec2-user@ip-172-31-71-40 ~]$ 
```

Same test was performed with the ARM64 system.