### PR TITLE
Updated Allocator module with OpenSUSE Leap 15.6 AMI

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -286,7 +286,7 @@ aws:
     user: ec2-user
   # openSUSE Linux
   linux-opensuse-15-amd64:
-    ami: ami-06b6eb8f8fb7f2916
+    ami: ami-012c22f49f1c32f31
     zone: us-east-1
     user: ec2-user
   # SUSE Linux


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->
---
The aim of this PR is to update the Allocator module with the OpenSUSE Leap 15.6 AMIs. 
Related: https://github.com/wazuh/wazuh/issues/24372. The system was updated following this documentation: https://en.opensuse.org/SDB:System_upgrade_to_Leap_15.5

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

An AMI was created from the updated system, and a test with the new AMI was performed:

```console
> python3 modules/allocation/main.py --action create --provider aws --size medium --composite-name linux-opensuse-15-amd64 --inventory-output "/tmp/dtt1-poc/opensuse-test/inventory.yaml" --track-output "/tmp/dtt1-poc/opensuse-test/track.yaml" --label-issue "https://github.com/wazuh/wazuh/issues/24372" --label-termination-date "1d" --label-team "devops"
[2024-07-01 18:23:43] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-01 18:23:45] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-01 18:23:45] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-01 18:23:45] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-23575426-CF48-45CB-8522-D1AD00F6D337
[2024-07-01 18:24:05] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-23575426-CF48-45CB-8522-D1AD00F6D337 directory to /tmp/wazuh-qa/i-0f46e1e2b27a77f40
[2024-07-01 18:24:05] [INFO] ALLOCATOR: Instance i-0f46e1e2b27a77f40 created.
[2024-07-01 18:24:06] [INFO] ALLOCATOR: Instance i-0f46e1e2b27a77f40 started.
[2024-07-01 18:24:07] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/opensuse-test/inventory.yaml
[2024-07-01 18:24:07] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/opensuse-test/track.yaml
[2024-07-01 18:26:21] [WARNING] ALLOCATOR: Error on attempt 1 of 30: [Errno 110] Connection timed out
[2024-07-01 18:26:52] [INFO] ALLOCATOR: SSH connection successful.
[2024-07-01 18:26:52] [INFO] ALLOCATOR: Instance i-0f46e1e2b27a77f40 created successfully. 

> ssh -i /tmp/wazuh-qa/i-0f46e1e2b27a77f40/wazuh-24372-opensuse-15-key-9681 ec2-user@ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com -p2200
The authenticity of host '[ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com]:2200 ([54.162.214.190]:2200)' can't be established.
ED25519 key fingerprint is SHA256:8jYpndKYJ2mlnqQm/8MhIblS2vhabNLCRugsBGUc1/Q.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '[ec2-XXX-XX-XX-XXX.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
openSUSE Leap 15.5 x86_64 (64-bit)
Suggestions email to: Alessandro de Oliveira Faria (A.K.A. CABELO) cabelo@opensuse.org

As "root" use the:
- zypper command for package management
- yast command for configuration management

Have a lot of fun...
Last login: Mon Jul  1 16:12:27 2024 from 79.117.226.210
openSUSE Leap 15.5 x86_64 (64-bit)
Suggestions email to: Alessandro de Oliveira Faria (A.K.A. CABELO) cabelo@opensuse.org

As "root" use the:
- zypper command for package management
- yast command for configuration management

Have a lot of fun...
ec2-user@ip-172-31-33-230:~> cat /etc/os-release
NAME="openSUSE Leap"
VERSION="15.6"
ID="opensuse-leap"
ID_LIKE="suse opensuse"
VERSION_ID="15.6"
PRETTY_NAME="openSUSE Leap 15.6"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:leap:15.6"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:Leap"
LOGO="distributor-logo-Leap"
ec2-user@ip-172-31-33-230:~> 

```
