### PR TITLE
Updated CentOS7 AMIs in Allocator module

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -300,11 +300,11 @@ aws:
     user: ec2-user
   # Centos
   linux-centos-7-amd64:
-    ami: ami-0aedf6b1cb669b4c7
+    ami: ami-0474061d40b48401a
     zone: us-east-1
     user: centos
   linux-centos-7-arm64:
-    ami: ami-08dbbdbfc4fa2f393
+    ami: ami-0376b30fe00ea638b
     zone: us-east-1
     user: centos
   linux-centos-8-amd64:


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/wazuh-qa/issues/5544
The aim of this PR is to update the CentOS7 AMIs of the Allocator module. The new AMI fixes the deprecation of the mirrorlists.

Testing is in: https://github.com/wazuh/wazuh-qa/issues/5544#issuecomment-2203279763