### PR TITLE
Updated CentOS7 Vagrant box in Allocator module

### DIFF
--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -61,8 +61,8 @@ vagrant:
     virtualizer: virtualbox
   # Centos
   linux-centos-7-amd64:
-    box: centos/7
-    box_version: 2004.01
+    box: vagrant_devel/centos-7
+    box_version: 1.1.0
     virtualizer: virtualbox
   linux-centos-7-ppc64:
     box: testing-centos-image


### PR DESCRIPTION
## Description

Related: https://github.com/wazuh/wazuh-qa/issues/5544
The aim of this PR is to update the CentOS7 Vagrant box. We have created a Vagrant Cloud account to store this kind of boxes.


The new box was tested with the Allocator module:

```console
> python3  modules/allocation/main.py --action create --provider vagrant --size micro --composite-name linux-centos-7-amd64 --inventory-output  /tmp/dtt1-poc/linux-centos-7-vg/inventory.yaml --track-output  /tmp/dtt1-poc/linux-centos-7-vg/track.yaml --instance-name linux-centos-7-amd64
[2024-07-03 12:51:04] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-03 12:51:05] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-03 12:51:05] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-03 12:51:09] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-07-03 12:51:09] [INFO] ALLOCATOR: Instance linux-centos-7-amd64-7149 created.
[2024-07-03 12:52:32] [INFO] ALLOCATOR: Instance linux-centos-7-amd64-7149 started.
[2024-07-03 12:52:36] [INFO] ALLOCATOR: The inventory file generated at /tmp/dtt1-poc/linux-centos-7-vg/inventory.yaml
[2024-07-03 12:52:36] [INFO] ALLOCATOR: The track file generated at /tmp/dtt1-poc/linux-centos-7-vg/track.yaml
[2024-07-03 12:52:36] [INFO] ALLOCATOR: SSH connection successful.
[2024-07-03 12:52:36] [INFO] ALLOCATOR: Instance linux-centos-7-amd64-7149 created successfully.

> ssh -i /tmp/wazuh-qa/linux-centos-7-amd64-7149/instance_key 192.168.57.115
The authenticity of host '192.168.57.115 (192.168.57.115)' can't be established.
ED25519 key fingerprint is SHA256:lbiAUdup7OT5Ffrk0eXFccFpF03E59kDdrY+nZT2bYM.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? ^C
 ✘  ~/Wazuh/wazuh-qa/deployability  ↱ bug/5544-fix-centos7-allocator ±  ssh -i /tmp/wazuh-qa/linux-centos-7-amd64-7149/instance_key vagrant@192.168.57.115
The authenticity of host '192.168.57.115 (192.168.57.115)' can't be established.
ED25519 key fingerprint is SHA256:lbiAUdup7OT5Ffrk0eXFccFpF03E59kDdrY+nZT2bYM.
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '192.168.57.115' (ED25519) to the list of known hosts.
Last login: Wed Jul  3 19:20:36 2024 from 10.0.2.2
[vagrant@localhost ~]$ sudo su
[root@localhost vagrant]# cat /etc/centos-release
CentOS Linux release 7.9.2009 (Core)
[root@localhost vagrant]# 
```
