### PR TITLE
Deleted custom field from PUT /active-response performance test.

### DIFF
--- a/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
+++ b/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
@@ -115,7 +115,6 @@ test_cases:
     parameters: {}
     body:
       command: custom
-      custom: True
     restart: False
 
   - endpoint: /rootcheck


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->

Deletes the field `custom` from the `PUT /active-response` request made in the API performance test.

---

## Testing performed

Testing was performed in https://github.com/wazuh/wazuh-qa/issues/5611#issuecomment-2251206896