### PR TITLE
Changed _run_tests in testing.py

### DIFF
--- a/deployability/modules/testing/testing.py
+++ b/deployability/modules/testing/testing.py
@@ -96,10 +96,12 @@ class Tester:
             rendering_var = {**extra_vars, 'test': test}
             template = str(cls._test_template)
             result = ansible.run_playbook(template, rendering_var)
+            for event in result.events:
+                logger.info(f"{event['stdout']}")
             if result.stats["failures"]:
                 for event in result.events:
                     if "fatal" in event['stdout']:
-                        raise Exception(f"Test {test} failed with error: {event['stdout']}")
+                        raise Exception(f"Test {test} failed with error")
 
 
     @classmethod


### PR DESCRIPTION
# Description

The new changes to the run_test method were applied to view the logs of past tests and need to be merged with the 4.9.0 branch

---

## Testing performed

The tests were performed in this issue: https://github.com/wazuh/wazuh/issues/24935. The pytest output can be observed there

|OS|Package used|
|--|--|
||Deployability 4.9.0|

| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | ⚫⚫ | :green_circle: :green_circle:  |         |     [changed _run_tests in testing.py](https://github.com/wazuh/wazuh-qa/commit/736cd35c3f34bcf770130fe6e469b460c48ecdc6)    | Nothing to highlight |