### PR TITLE
Fix cluster reliability test internal error

### DIFF
--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py
@@ -13,7 +13,7 @@ from yaml import safe_load
 test_data_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'data')
 logs_format = re.compile(
     r'(.*) \[(Local agent-groups|Agent-groups send full|Agent-groups send)] (.*)')
-incorrect_order = []
+incorrect_order = {}
 
 
 # Classes
@@ -90,11 +90,11 @@ def test_check_logs_order_master(artifacts_path):
                                 tree_info['tree'].children(child.identifier) else 'root'
                             break
                     else:
-                        incorrect_order.append({'node': name, 'log_type': log_tag,
+                        incorrect_order[name].append({'node': name, 'log_type': log_tag,
                                                 'expected_logs': [log.tag for log in
                                                                   tree_info['tree'].children(tree_info['node'])],
                                                 'found_log': full_log})
-                        pytest.fail(f"[{incorrect_order[0]['node']}]"
-                                    f"\n - Log type: {incorrect_order[0]['log_type']}"
-                                    f"\n - Expected logs: {incorrect_order[0]['expected_logs']}"
-                                    f"\n - Found log: {incorrect_order[0]['found_log']}")
+                        pytest.fail(f"[{incorrect_order[name]['node']}]"
+                                    f"\n - Log type: {incorrect_order[name]['log_type']}"
+                                    f"\n - Expected logs: {incorrect_order[name]['expected_logs']}"
+                                    f"\n - Found log: {incorrect_order[name]['found_log']}")


### PR DESCRIPTION
|Related issue|
|---|
| Closes https://github.com/wazuh/wazuh-qa/issues/5281 |

# Description

Modifies the `incorrect_order` variable to be a dictionary instead of a list. This fixes an internal error that was causing the last three tests to not be executed.

<details><summary>Error</summary>

```console
[2024-07-23T23:33:15.190Z] + python3 -m pytest /home/ec2-user/workspace/CLUSTER-Workload_benchmarks_metrics/wazuh-qa/tests/reliability/test_cluster --artifacts_path /mnt/efs/tmp/CLUSTER-Workload_benchmarks_metrics/B_590 --html=test_cluster_reliability.html --self-contained-html
[2024-07-23T23:33:15.761Z] ============================= test session starts ==============================
[2024-07-23T23:33:15.761Z] platform linux -- Python 3.7.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
[2024-07-23T23:33:15.761Z] rootdir: /home/ec2-user/workspace/CLUSTER-Workload_benchmarks_metrics/wazuh-qa/tests, configfile: pytest.ini
[2024-07-23T23:33:15.761Z] plugins: testinfra-5.0.0, metadata-2.0.4, html-3.1.1
[2024-07-23T23:33:15.761Z] collected 6 items
[2024-07-23T23:33:15.761Z] 
[2024-07-23T23:33:21.020Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py . [ 16%]
[2024-07-23T23:33:21.021Z]                                                                          [ 16%]
[2024-07-23T23:33:26.271Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_error_logs/test_cluster_error_logs.py F [ 33%]
[2024-07-23T23:33:26.271Z]                                                                          [ 33%]
[2024-07-23T23:35:47.721Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py F
[2024-07-23T23:35:47.721Z] INTERNALERROR> Traceback (most recent call last):
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/_pytest/main.py", line 269, in wrap_session
[2024-07-23T23:35:47.721Z] INTERNALERROR>     session.exitstatus = doit(config, session) or 0
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/_pytest/main.py", line 323, in _main
[2024-07-23T23:35:47.721Z] INTERNALERROR>     config.hook.pytest_runtestloop(session=session)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
[2024-07-23T23:35:47.721Z] INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return outcome.get_result()
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
[2024-07-23T23:35:47.721Z] INTERNALERROR>     raise ex[1].with_traceback(ex[2])
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
[2024-07-23T23:35:47.721Z] INTERNALERROR>     res = hook_impl.function(*args)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/_pytest/main.py", line 348, in pytest_runtestloop
[2024-07-23T23:35:47.721Z] INTERNALERROR>     item.config.hook.pytest_runtest_protocol(item=item, nextitem=nextitem)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
[2024-07-23T23:35:47.721Z] INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return outcome.get_result()
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
[2024-07-23T23:35:47.721Z] INTERNALERROR>     raise ex[1].with_traceback(ex[2])
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
[2024-07-23T23:35:47.721Z] INTERNALERROR>     res = hook_impl.function(*args)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/_pytest/runner.py", line 109, in pytest_runtest_protocol
[2024-07-23T23:35:47.721Z] INTERNALERROR>     runtestprotocol(item, nextitem=nextitem)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/_pytest/runner.py", line 127, in runtestprotocol
[2024-07-23T23:35:47.721Z] INTERNALERROR>     reports.append(call_and_report(item, "teardown", log, nextitem=nextitem))
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/_pytest/runner.py", line 217, in call_and_report
[2024-07-23T23:35:47.721Z] INTERNALERROR>     report: TestReport = hook.pytest_runtest_makereport(item=item, call=call)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return self._hookexec(self, self.get_hookimpls(), kwargs)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
[2024-07-23T23:35:47.721Z] INTERNALERROR>     return self._inner_hookexec(hook, methods, kwargs)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
[2024-07-23T23:35:47.721Z] INTERNALERROR>     firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/.local/lib/python3.7/site-packages/pluggy/callers.py", line 203, in _multicall
[2024-07-23T23:35:47.721Z] INTERNALERROR>     gen.send(outcome)
[2024-07-23T23:35:47.721Z] INTERNALERROR>   File "/home/ec2-user/workspace/CLUSTER-Workload_benchmarks_metrics/wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/conftest.py", line 112, in pytest_runtest_makereport
[2024-07-23T23:35:47.721Z] INTERNALERROR>     for key in sorted(item.module.incorrect_order.keys(),
[2024-07-23T23:35:47.721Z] INTERNALERROR> AttributeError: 'list' object has no attribute 'keys'
[2024-07-23T23:35:47.721Z] 
[2024-07-23T23:35:47.721Z] =================== 2 failed, 1 passed in 142.44s (0:02:22) ====================
```

</details>

## Testing performed

|OS|Package used|
|--|--|
| Debian 10 | 4.9.0-1 |

| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|     [Build](https://ci.wazuh.info/job/CLUSTER-Workload_benchmarks_metrics/594)      | 🟢 | ⚫⚫ |         |     908ebcee64a5cbec6bcbf3b93767ff5f0bc0250e    | [Artifacts](https://github.com/user-attachments/files/16415423/artifacts.zip) |
|     [Build with performance tests](https://ci.wazuh.info/job/CLUSTER-Workload_benchmarks_metrics/597)      | 🟢 | ⚫⚫ |         |     908ebcee64a5cbec6bcbf3b93767ff5f0bc0250e    | [Artifacts](https://github.com/user-attachments/files/16416909/artifacts.zip) |

<details><summary>Tests results</summary>

```console
[2024-07-29T15:14:03.373Z] + python3 -m pytest /home/ec2-user/workspace/CLUSTER-Workload_benchmarks_metrics/wazuh-qa/tests/reliability/test_cluster --artifacts_path /mnt/efs/tmp/CLUSTER-Workload_benchmarks_metrics/B_594 --html=test_cluster_reliability.html --self-contained-html
[2024-07-29T15:14:03.936Z] ============================= test session starts ==============================
[2024-07-29T15:14:03.936Z] platform linux -- Python 3.7.10, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
[2024-07-29T15:14:03.936Z] rootdir: /home/ec2-user/workspace/CLUSTER-Workload_benchmarks_metrics/wazuh-qa/tests, configfile: pytest.ini
[2024-07-29T15:14:03.936Z] plugins: testinfra-5.0.0, metadata-2.0.4, html-3.1.1
[2024-07-29T15:14:03.936Z] collected 6 items
[2024-07-29T15:14:03.936Z] 
[2024-07-29T15:14:04.192Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py . [ 16%]
[2024-07-29T15:14:04.192Z]                                                                          [ 16%]
[2024-07-29T15:14:04.192Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_error_logs/test_cluster_error_logs.py . [ 33%]
[2024-07-29T15:14:04.192Z]                                                                          [ 33%]
[2024-07-29T15:14:05.558Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_master_logs_order/test_cluster_master_logs_order.py . [ 50%]
[2024-07-29T15:14:05.559Z]                                                                          [ 50%]
[2024-07-29T15:14:05.816Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py . [ 66%]
[2024-07-29T15:14:05.816Z]                                                                          [ 66%]
[2024-07-29T15:14:05.816Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_task_order/test_cluster_task_order.py . [ 83%]
[2024-07-29T15:14:05.816Z]                                                                          [ 83%]
[2024-07-29T15:14:06.077Z] wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_worker_logs_order/test_cluster_worker_logs_order.py . [100%]
[2024-07-29T15:14:06.077Z] 
[2024-07-29T15:14:06.077Z] - generated html file: file:///home/ec2-user/workspace/CLUSTER-Workload_benchmarks_metrics/test_cluster_reliability.html -
[2024-07-29T15:14:06.077Z] ============================== 6 passed in 2.27s ===============================
```

</details>

![tests](https://github.com/user-attachments/assets/d40572df-d0e1-4863-b76c-35a2d7eab186)

> The performance test from the second build failed, this will be investigated in https://github.com/wazuh/wazuh-qa/issues/4298.