### PR TITLE
Add task information in the allocation logs when create or delete an instance

### DIFF
--- a/deployability/modules/allocation/aws/provider.py
+++ b/deployability/modules/allocation/aws/provider.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta
 import subprocess
 
 from modules.allocation.generic import Provider
-from modules.allocation.generic.models import CreationPayload, InstancePayload, InstancePayload
+from modules.allocation.generic.models import CreationPayload, InstancePayload
 from modules.allocation.generic.utils import logger
 from .credentials import AWSCredentials
 from .instance import AWSInstance
@@ -129,6 +129,7 @@ class AWSProvider(Provider):
 
         instance_params = {}
         instance_params['instance_dir'] = instance_dir
+        instance_params['name'] = config.name
         instance_params['identifier'] = instance_id
         instance_params['platform'] = platform
         instance_params['host_identifier'] = host_identifier

--- a/deployability/modules/allocation/generic/instance.py
+++ b/deployability/modules/allocation/generic/instance.py
@@ -4,7 +4,6 @@
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from .utils import logger
 
 from .credentials import Credentials
 from .models import ConnectionInfo, InstancePayload
@@ -43,6 +42,7 @@ class Instance(ABC):
 
         self.path: Path = path
         self.identifier: str = str(instance_parameters.identifier)
+        self.name: str = instance_parameters.name
         self.credentials: Credentials = credentials
         self.host_identifier: str = instance_parameters.host_identifier
         self.host_instance_dir: Path = instance_parameters.host_instance_dir

--- a/deployability/modules/allocation/generic/models.py
+++ b/deployability/modules/allocation/generic/models.py
@@ -36,6 +36,7 @@ class InventoryOutput(BaseModel):
 
 class TrackOutput(BaseModel):
     identifier: str
+    name: str
     provider: str
     instance_dir: str
     key_path: str
@@ -116,6 +117,7 @@ class TrackPayload(BaseModel):
 
 class InstancePayload(BaseModel):
     identifier: str
+    name: str | None = None
     instance_dir: str | Path
     key_path: Path | None = None
     host_identifier: str  | None = None

--- a/deployability/modules/allocation/generic/utils.py
+++ b/deployability/modules/allocation/generic/utils.py
@@ -2,6 +2,27 @@
 # Created by Wazuh, Inc. <info@wazuh.com>.
 # This program is a free software; you can redistribute it and/or modify it under the terms of GPLv2
 
+import logging
+from modules.allocation.generic.instance import Instance
+from modules.allocation.generic.models import TrackOutput
 from modules.generic.logger import Logger
 
+# Default logger
 logger = Logger("allocator").get_logger()
+
+
+def logger_with_instance_name(instance_info: Instance | TrackOutput) -> logging.Logger:
+    """
+    Returns a logger with the instance name if it is different from the identifier,
+    otherwise returns the default logger without the name.
+
+    Args:
+        instance (Instance): The instance object.
+
+    Returns:
+        logging.Logger: The logger object.
+    """
+
+    if instance_info.name != instance_info.identifier:
+        return Logger(f"allocator [{instance_info.name}]").get_logger()
+    return logger

--- a/deployability/modules/allocation/vagrant/provider.py
+++ b/deployability/modules/allocation/vagrant/provider.py
@@ -121,6 +121,7 @@ class VagrantProvider(Provider):
         instance_params = {}
         instance_params['instance_dir'] = instance_dir
         instance_params['identifier'] = instance_id
+        instance_params['name'] = config.name
         instance_params['platform'] = platform
         instance_params['host_identifier'] = host_identifier
         instance_params['host_instance_dir'] = host_instance_dir


### PR DESCRIPTION
| Related issue |
|---|
| https://github.com/wazuh/wazuh-qa/issues/5614 |

# Description

When an instance was created or deleted, the logs only contained information about the instance ID, making it difficult to recognize each instance if more than one was created or deleted at the same time.

To improve this, more details have been added to the logs to identify the instance more easily. When an action is performed with the instance, the logs now display both the name and ID of the current instance.

- Before:

```console
[2024-07-30 11:42:26] [INFO] ALLOCATOR: Instance i-02de975e0d07f8b70 created.
[2024-07-30 11:42:27] [INFO] ALLOCATOR: Instance i-02de975e0d07f8b70 started.
```

- After:

```console
[2024-07-30 11:42:26] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: Instance i-02de975e0d07f8b70 created.
[2024-07-30 11:42:27] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: Instance i-02de975e0d07f8b70 started.
```

>[!NOTE]
>This change is only effective for instance creation in AWS because when creating a VM with vagrant the identifier is the machine name itself and it does not make sense to display it twice.

Additionally, the issue has been fixed where, when rolling back the creation of an instance, the message `[yyy-mm-dd hh:mm:ss] [INFO] ALLOCATOR: Instance i-<id> deleted` was displayed twice along with the message `[yyy-mm-dd hh:mm:ss] [INFO] ALLOCATOR: Instance i-<id> created successfully`, which was contradictory.

- Before

```console
[2024-07-30 12:36:26] [INFO] ALLOCATOR: Instance i-02de975e0d07f8b70 deleted.
[2024-07-30 12:36:26] [INFO] ALLOCATOR: Instance i-02de975e0d07f8b70 deleted.
[2024-07-30 12:36:26] [INFO] ALLOCATOR: Instance i-02de975e0d07f8b70 created successfully.
```

- After

```console
[2024-07-30 12:36:26] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: Instance i-02de975e0d07f8b70 deleted.
```

## Tests

- Create instance

<details><summary>AWS</summary>

 - With `--label-issue`
```console
root@ip-172-31-47-84:/home/ubuntu/wazuh-qa/deployability# python3 modules/allocation/main.py --action create --provider aws --size micro --composite-name linux-ubuntu-22.04-amd64 --inventory-output "/tmp/4-9-0/logs-tests-5614/inventory.yaml" --track-output "/tmp/4-9-0/logs-tests-5614/track.yaml" --label-issue "https://github.com/wazuh/wazuh-qa/issues/5614" --label-termination-date "1d" --label-team "devops"
[2024-07-30 11:41:51] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-07-30 11:41:51] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-07-30 11:41:52] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-30 11:41:53] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-30 11:41:53] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-30 11:41:53] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-F289F5C9-D745-42AD-A0BB-EF1CC17AAC24
[2024-07-30 11:42:26] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-F289F5C9-D745-42AD-A0BB-EF1CC17AAC24 directory to /tmp/wazuh-qa/i-02de975e0d07f8b70
[2024-07-30 11:42:26] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: Instance i-02de975e0d07f8b70 created.
[2024-07-30 11:42:27] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: Instance i-02de975e0d07f8b70 started.
[2024-07-30 11:42:27] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: The inventory file generated at /tmp/4-9-0/logs-tests-5614/inventory.yaml
[2024-07-30 11:42:27] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: The track file generated at /tmp/4-9-0/logs-tests-5614/track.yaml
[2024-07-30 11:42:27] [WARNING] ALLOCATOR [QA-5614-UBUNTU-22.04]: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 44.220.161.87
[2024-07-30 11:42:57] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: SSH connection successful.
[2024-07-30 11:42:57] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: Instance i-02de975e0d07f8b70 created successfully.
```

- With `--instance-name`

```console
root@ip-172-31-47-84:/home/ubuntu/wazuh-qa/deployability# python3 modules/allocation/main.py --action create --provider aws --size micro --composite-name linux-ubuntu-22.04-amd64 --instance-name test-log-ubuntu22 --inventory-output "/tmp/4-9-0/logs-tests-5614/inventory.yaml" --track-output "/tmp/4-9-0/logs-tests-5614/track.yaml" --label-termination-date "1d" --label-team "devops"
[2024-07-30 15:05:38] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-07-30 15:05:38] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-07-30 15:05:38] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-30 15:05:40] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-30 15:05:40] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-30 15:05:40] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-28F7B360-94CE-4E72-BCC2-A4601AF4871F
[2024-07-30 15:06:13] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-28F7B360-94CE-4E72-BCC2-A4601AF4871F directory to /tmp/wazuh-qa/i-08a1339f597510bd4
[2024-07-30 15:06:13] [INFO] ALLOCATOR [TEST-LOG-UBUNTU22]: Instance i-08a1339f597510bd4 created.
[2024-07-30 15:06:14] [INFO] ALLOCATOR [TEST-LOG-UBUNTU22]: Instance i-08a1339f597510bd4 started.
[2024-07-30 15:06:14] [INFO] ALLOCATOR [TEST-LOG-UBUNTU22]: The inventory file generated at /tmp/4-9-0/logs-tests-5614/inventory.yaml
[2024-07-30 15:06:14] [INFO] ALLOCATOR [TEST-LOG-UBUNTU22]: The track file generated at /tmp/4-9-0/logs-tests-5614/track.yaml
[2024-07-30 15:06:17] [WARNING] ALLOCATOR [TEST-LOG-UBUNTU22]: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 34.227.59.35
[2024-07-30 15:06:47] [INFO] ALLOCATOR [TEST-LOG-UBUNTU22]: SSH connection successful.
[2024-07-30 15:06:47] [INFO] ALLOCATOR [TEST-LOG-UBUNTU22]: Instance i-08a1339f597510bd4 created successfully
```

- With `--composite-name`

```console
root@ip-172-31-47-84:/home/ubuntu/wazuh-qa/deployability# python3 modules/allocation/main.py --action create --provider aws --size micro --composite-name linux-ubuntu-22.04-amd64 --inventory-output "/tmp/4-9-0/logs-tests-5614/inventory.yaml" --track-output "/tmp/4-9-0/logs-tests-5614/track.yaml" --label-termination-date "1d" --label-team "devops"
[2024-07-30 14:21:59] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-07-30 14:21:59] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-07-30 14:21:59] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-30 14:22:01] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-30 14:22:01] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-30 14:22:01] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-503C1FAA-4CBF-4522-B1AF-7CABD15DBDEA
[2024-07-30 14:22:34] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-503C1FAA-4CBF-4522-B1AF-7CABD15DBDEA directory to /tmp/wazuh-qa/i-0937cedffbaa4c8db
[2024-07-30 14:22:34] [INFO] ALLOCATOR [UBUNTU-22.04-AMD64]: Instance i-0937cedffbaa4c8db created.
[2024-07-30 14:22:35] [INFO] ALLOCATOR [UBUNTU-22.04-AMD64]: Instance i-0937cedffbaa4c8db started.
[2024-07-30 14:22:35] [INFO] ALLOCATOR [UBUNTU-22.04-AMD64]: The inventory file generated at /tmp/4-9-0/logs-tests-5614/inventory.yaml
[2024-07-30 14:22:35] [INFO] ALLOCATOR [UBUNTU-22.04-AMD64]: The track file generated at /tmp/4-9-0/logs-tests-5614/track.yaml
[2024-07-30 14:22:38] [WARNING] ALLOCATOR [UBUNTU-22.04-AMD64]: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 3.89.38.8
[2024-07-30 14:23:08] [INFO] ALLOCATOR [UBUNTU-22.04-AMD64]: SSH connection successful.
[2024-07-30 14:23:08] [INFO] ALLOCATOR [UBUNTU-22.04-AMD64]: Instance i-0937cedffbaa4c8db created successfully.
```

</details>

<details><summary>Vagrant</summary>

```console
$ python3 modules/allocation/main.py --action create --provider vagrant --size micro --composite-name linux-centos-7-amd64 --inventory-output  /tmp/4-9-0/linux-centos-7-vg/inventory.yaml --track-output  /tmp/4-9-0/linux-centos-7-vg/track.yaml --instance-name linux-centos-7-amd64
[2024-07-30 14:13:18] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-07-30 14:13:18] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-07-30 14:13:18] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-07-30 14:13:18] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-07-30 14:13:18] [DEBUG] ALLOCATOR: Generating new key pair
[2024-07-30 14:13:22] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-07-30 14:13:22] [INFO] ALLOCATOR: Instance linux-centos-7-amd64-1779 created.
[2024-07-30 14:15:58] [INFO] ALLOCATOR: Instance linux-centos-7-amd64-1779 started.
[2024-07-30 14:16:00] [INFO] ALLOCATOR: The inventory file generated at /tmp/4-9-0/linux-centos-7-vg/inventory.yaml
[2024-07-30 14:16:00] [INFO] ALLOCATOR: The track file generated at /tmp/4-9-0/linux-centos-7-vg/track.yaml
[2024-07-30 14:16:00] [INFO] ALLOCATOR: SSH connection successful.
[2024-07-30 14:16:00] [INFO] ALLOCATOR: Instance linux-centos-7-amd64-1779 created successfully.
```

As shown, the logs with vagrant are not modified.

</details>

- Delete instance

<details><summary>AWS</summary>

```console
root@ip-172-31-47-84:/home/ubuntu/wazuh-qa/deployability# python3 modules/allocation/main.py --action delete --track-output "/tmp/4-9-0/logs-tests-5614/track.yaml"
[2024-07-30 12:35:39] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-07-30 12:35:39] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-07-30 12:35:39] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/4-9-0/logs-tests-5614/track.yaml
[2024-07-30 12:35:40] [DEBUG] ALLOCATOR: Deleting credentials: qa-5614-ubuntu-22.04-key-8181
[2024-07-30 12:36:26] [INFO] ALLOCATOR [QA-5614-UBUNTU-22.04]: Instance i-02de975e0d07f8b70 deleted.
```

</details>

<details><summary>Vagrant</summary>

```console
$ python3 modules/allocation/main.py --action delete --track-output  "/tmp/4-9-0/linux-centos-7-vg/track.yaml"
[2024-07-30 14:32:16] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-07-30 14:32:16] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-07-30 14:32:16] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/4-9-0/linux-centos-7-vg/track.yaml
[2024-07-30 14:32:16] [DEBUG] ALLOCATOR: Destroying instance linux-centos-7-amd64-1779
[2024-07-30 14:32:20] [INFO] ALLOCATOR: Instance linux-centos-7-amd64-1779 deleted.
```

</details>