### PR TITLE
Vulnerability regex changed to match with 4.9.0 solved vulnerability alerts

### DIFF
--- a/deps/wazuh_testing/wazuh_testing/end_to_end/regex.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/regex.py
@@ -49,7 +49,7 @@ REGEX_PATTERNS = {
         'regex':  'CVE.* affects.*"?'
     },
     'vuln_mitigated': {
-        'regex': "The .* that affected .* was solved due to a package removal.*"
+        'regex': "The .* that affected .* was solved due to an update in the agent or feed.*"
     }
 }
 


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->

This pull request is based on https://github.com/wazuh/wazuh-qa/issues/5608. 

Concerning the detection of vulnerability mitigation alerts despite the change in the rule description, the change implemented in the regex module has managed to get all mitigated alerts detected except for those related to agent 2 and agent 5, which are the ones that give problems with vulnerability detection (as indicated in the issue above) so that no mitigated alerts can be detected. Here is the evidence:
- Build: https://ci.wazuh.info/job/Test_e2e_system/335/
- Evidence: [Test_e2e_system_335_test_vulnerability_detector.zip](https://ci.wazuh.info/job/Test_e2e_system/335/artifact/335/Test_e2e_system_335_test_vulnerability_detector.zip)

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

|OS|Package used|
|--|--|
|||

| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | :green_circle: :green_circle:  | ⚫⚫ |         |     [Vulnerability regex changed to match with 4.9.0 solved vulnerability alert](https://github.com/wazuh/wazuh-qa/commit/f7ad4d1382245ea03f88263ad152eeae8e772b96)    | Nothing to highlight |