### PR TITLE
Adding fixed and dynamic waits to port status checks

### DIFF
--- a/deployability/modules/testing/tests/helpers/dashboard.py
+++ b/deployability/modules/testing/tests/helpers/dashboard.py
@@ -90,6 +90,7 @@ class WazuhDashboard:
         Returns:
             str: OS name.
         """
+        time.sleep(5)
         wait_cycles = 0
         while wait_cycles < cycles:
             ports = ConnectionManager.execute_commands(inventory_path, 'ss -t -a -n | grep ":443"').get('output') or ""

--- a/deployability/modules/testing/tests/helpers/indexer.py
+++ b/deployability/modules/testing/tests/helpers/indexer.py
@@ -95,6 +95,7 @@ class WazuhIndexer:
         Returns:
             str: OS name.
         """
+        time.sleep(5)
         wait_cycles = 0
         while wait_cycles < cycles:
             ports = ConnectionManager.execute_commands(inventory_path, 'ss -t -a -n | grep ":9200"').get('output') or ""

--- a/deployability/modules/testing/tests/helpers/manager.py
+++ b/deployability/modules/testing/tests/helpers/manager.py
@@ -241,6 +241,7 @@ class WazuhManager:
         Returns:
             bool: True if port is opened.
         """
+        time.sleep(5)
         wait_cycles = 0
         while wait_cycles < cycles:
             ports = ConnectionManager.execute_commands(inventory_path, 'ss -t -a -n | grep ":443"').get('output') or ""
@@ -266,6 +267,7 @@ class WazuhManager:
         Returns:
             bool: True if port is opened.
         """
+        time.sleep(5)
         wait_cycles = 0
         while wait_cycles < cycles:
             ports = ConnectionManager.execute_commands(inventory_path, 'ss -t -a -n | grep ":1514"').get('output') or ""
@@ -291,6 +293,7 @@ class WazuhManager:
         Returns:
             bool: True if port is opened.
         """
+        time.sleep(5)
         wait_cycles = 0
         while wait_cycles < cycles:
             ports = ConnectionManager.execute_commands(inventory_path, 'ss -t -a -n | grep ":443"').get('output') or ""


### PR DESCRIPTION
# Description

Adding fixed and dynamic waits to port status checks

---

## Testing performed

<details><summary>Central Components YAML</summary>

```
version: 0.1
description: This workflow is used to test the Wazuh manager deployment for DDT1 PoC
variables:
  central_components-os:
    - linux-ubuntu-20.04-amd64
    - linux-ubuntu-22.04-amd64
    - linux-amazon-2-amd64
    - linux-redhat-7-amd64
    - linux-redhat-8-amd64
    - linux-redhat-9-amd64
    - linux-centos-7-amd64
    - linux-centos-8-amd64
    - linux-debian-10-amd64
    - linux-debian-11-amd64
    - linux-debian-12-amd64
  infra-provider: aws
  working-dir: /tmp/dtt1-poc

tasks:
  # Unique central components allocate task
  - task: "allocate-central_components-{central_components}"
    description: "Allocate resources for the central_components."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: create
          - provider: "{infra-provider}"
          - size: large
          - composite-name: "{central_components}"
          - inventory-output: "{working-dir}/central_components-{central_components}/inventory.yaml"
          - track-output: "{working-dir}/central_components-{central_components}/track.yaml"
          - label-termination-date: "1d"
          - label-team: "qa"
          - label-issue: "https://github.com/wazuh/wazuh/issues/24935"
    foreach:
      - variable: central_components-os
        as: central_components
    cleanup:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: delete
          - track-output: "{working-dir}/central_components-{central_components-os}/track.yaml"

  # Generic manager test task
  - task: "run-central_components-{central_components}-tests"
    description: "Run tests install for the central_components."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/testing/main.py
          - targets:
            - wazuh-1: "{working-dir}/central_components-{central_components}/inventory.yaml"
          - tests: "install,restart,stop,uninstall"
          - component: "central_components"
          - wazuh-version: "4.9.0"
          - wazuh-revision: "40903"
          - live: False
    foreach:
      - variable: central_components-os
        as: central_components
    depends-on:
      - "allocate-central_components-linux-ubuntu-20.04-amd64"
      - "allocate-central_components-linux-ubuntu-22.04-amd64"
      - "allocate-central_components-linux-amazon-2-amd64"
      - "allocate-central_components-linux-redhat-7-amd64"
      - "allocate-central_components-linux-redhat-8-amd64"
      - "allocate-central_components-linux-redhat-8-amd64"
      - "allocate-central_components-linux-redhat-9-amd64"
      - "allocate-central_components-linux-centos-7-amd64"
      - "allocate-central_components-linux-centos-8-amd64"
      - "allocate-central_components-linux-debian-10-amd64"
      - "allocate-central_components-linux-debian-11-amd64"
      - "allocate-central_components-linux-debian-12-amd64"

```
</details>

[Central_components.log](https://github.com/user-attachments/files/16438992/Central_components.log)


<details><summary>Agents YAML</summary>

```
version: 0.1
description: This workflow is used to test agents deployment for DDT1 PoC
variables:
  agent-os:
    - linux-redhat-7-amd64
    - linux-redhat-7-arm64
    - linux-redhat-8-amd64
    - linux-redhat-8-arm64
    - linux-redhat-9-amd64
    - linux-redhat-9-arm64
    - linux-centos-7-amd64
    - linux-centos-7-arm64
    - linux-centos-8-amd64
    - linux-centos-8-arm64
    - linux-debian-10-amd64
    - linux-debian-10-arm64
    - linux-debian-11-amd64
    - linux-debian-11-arm64
    - linux-debian-12-amd64
    - linux-debian-12-arm64
    - linux-ubuntu-22.04-amd64
    - linux-ubuntu-22.04-arm64
    - linux-ubuntu-18.04-amd64
    - linux-ubuntu-18.04-arm64
    - linux-ubuntu-20.04-amd64
    - linux-ubuntu-20.04-arm64
    - linux-oracle-9-amd64
    - linux-amazon-2-amd64
    - linux-amazon-2-arm64
    - linux-amazon-2023-amd64
    - linux-amazon-2023-arm64

  windows-agent-os:
    - windows-desktop-10-amd64
    - windows-server-2012r2-amd64
    - windows-server-2016-amd64
    - windows-server-2019-amd64
    - windows-server-2022-amd64

  #macos-agent-os:
  #  - macos-ventura-13-amd64
  #  - macos-sonoma-14-amd64

  manager-os: linux-ubuntu-22.04-amd64
  infra-provider: aws
  macos-infra-provider: vagrant
  working-dir: /tmp/dtt1-poc

tasks:
  # Unique manager allocate task
  - task: "allocate-manager-{manager-os}"
    description: "Allocate resources for the manager."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: create
          - provider: "{infra-provider}"
          - size: large
          - composite-name: "{manager-os}"
          - inventory-output: "{working-dir}/manager-{manager-os}/inventory.yaml"
          - track-output: "{working-dir}/manager-{manager-os}/track.yaml"
          - label-termination-date: "1d"
          - label-team: "qa"
          - label-issue: "https://github.com/wazuh/wazuh/issues/24935"
    cleanup:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: delete
          - track-output: "{working-dir}/manager-{manager-os}/track.yaml"

  # Unique manager provision task
  - task: "provision-manager-{manager-os}"
    description: "Provision the manager."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/provision/main.py
          - inventory: "{working-dir}/manager-{manager-os}/inventory.yaml"
          - install:
            - component: wazuh-manager
              type: assistant
              version: 4.9.0
              live: False
    depends-on:
      - "allocate-manager-{manager-os}"
    on-error: "abort-all"

  # Unique agent allocate task
  - task: "allocate-agent-{agent}"
    description: "Allocate resources for the agent."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: create
          - provider: "{infra-provider}"
          - size: small
          - composite-name: "{agent}"
          - inventory-output: "{working-dir}/agent-{agent}/inventory.yaml"
          - track-output: "{working-dir}/agent-{agent}/track.yaml"
          - label-termination-date: "1d"
          - label-team: "qa"
          - label-issue: "https://github.com/wazuh/wazuh/issues/24935"
    foreach:
      - variable: agent-os
        as: agent
    depends-on:
      - "provision-manager-{manager-os}"
    cleanup:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: delete
          - track-output: "{working-dir}/agent-{agent}/track.yaml"

  # Generic agent test task
  - task: "run-agent-{agent}-tests"
    description: "Run tests install for the agent {agent}."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/testing/main.py
          - targets:
            - wazuh-1: "{working-dir}/manager-{manager-os}/inventory.yaml"
            - agent: "{working-dir}/agent-{agent}/inventory.yaml"
          - tests: "install,registration,connection,basic_info,restart,stop,uninstall"
          - component: "agent"
          - wazuh-version: "4.9.0"
          - wazuh-revision: "40903"
          - live: False
    foreach:
      - variable: agent-os
        as: agent
    depends-on:
      - "allocate-agent-{agent}"

  # Unique agent allocate task
  #- task: "allocate-macos-agent-{agent}"
  #  description: "Allocate resources for the agent."
  #  do:
  #    this: process
  #    with:
  #      path: python3
  #      args:
  #        - modules/allocation/main.py
  #        - action: create
  #        - provider: "{macos-infra-provider}"
  #        - size: small
  #        - composite-name: "{agent}"
  #        - inventory-output: "{working-dir}/agent-{agent}/inventory.yaml"
  #        - track-output: "{working-dir}/agent-{agent}/track.yaml"
  #        - label-termination-date: "1d"
  #        - label-team: "qa"
  #        - label-issue: "https://github.com/wazuh/wazuh/issues/24935"
  #  foreach:
  #    - variable: macos-agent-os
  #      as: agent
  #  depends-on:
  #    - "provision-manager-{manager-os}"
  #  cleanup:
  #    this: process
  #    with:
  #      path: python3
  #      args:
  #        - modules/allocation/main.py
  #        - action: delete
  #        - track-output: "{working-dir}/agent-{agent}/track.yaml"

  # Generic agent test task
  #- task: "run-macos-agent-{agent}-tests"
  #  description: "Run tests install for the agent {agent}."
  #  do:
  #    this: process
  #    with:
  #      path: python3
  #      args:
  #        - modules/testing/main.py
  #        - targets:
  #          - wazuh-1: "{working-dir}/manager-{manager-os}/inventory.yaml"
  #          - agent: "{working-dir}/agent-{agent}/inventory.yaml"
  #        - tests: "install,registration,connection,basic_info,restart,stop,uninstall"
  #        - component: "agent"
  #        - wazuh-version: "4.9.0"
  #        - wazuh-revision: "40903"
  #        - live: False
  #  foreach:
  #    - variable: macos-agent-os
  #      as: agent
  #  depends-on:
  #    - "allocate-macos-agent-{agent}"

  # Unique agent allocate task
  - task: "allocate-windows-agent-{agent}"
    description: "Allocate resources for the agent."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: create
          - provider: "{infra-provider}"
          - size: large
          - composite-name: "{agent}"
          - inventory-output: "{working-dir}/agent-{agent}/inventory.yaml"
          - track-output: "{working-dir}/agent-{agent}/track.yaml"
          - label-termination-date: "1d"
          - label-team: "qa"
          - label-issue: "https://github.com/wazuh/wazuh/issues/24935"
    foreach:
      - variable: windows-agent-os
        as: agent
    depends-on:
      - "provision-manager-{manager-os}"
    cleanup:
      this: process
      with:
        path: python3
        args:
          - modules/allocation/main.py
          - action: delete
          - track-output: "{working-dir}/agent-{agent}/track.yaml"

  # Generic agent test task
  - task: "run-windows-agent-{agent}-tests"
    description: "Run tests install for the agent {agent}."
    do:
      this: process
      with:
        path: python3
        args:
          - modules/testing/main.py
          - targets:
            - wazuh-1: "{working-dir}/manager-{manager-os}/inventory.yaml"
            - agent: "{working-dir}/agent-{agent}/inventory.yaml"
          - tests: "install,registration,connection,basic_info,restart,stop,uninstall"
          - component: "agent"
          - wazuh-version: "4.9.0"
          - wazuh-revision: "40903"
          - live: False
    foreach:
      - variable: windows-agent-os
        as: agent
    depends-on:
      - "allocate-windows-agent-{agent}"

```
</details>

[Agent_test.log](https://github.com/user-attachments/files/16439008/Agent_test.log)
