### PR TITLE
Changed 'Ensure that the manager version is' expected warning to an agnostic version of regex

### DIFF
--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -89,7 +89,7 @@ VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS = [
     r"Lost connection with manager. Setting lock",
     r"Unable to connect to .*Connection refused",
     r"Unable to connect to .*No connection could be made because the target machine actively refused it",
-    r"Waiting for server reply \(not started\). Tried: .*Ensure that the manager version is 'v4.8.0' or higher",
+    r"Waiting for server reply \(not started\). Tried: .*Ensure that the manager version is .*",
     r"Unable to connect to any server",
     r"Agent key already in use"
 ]


### PR DESCRIPTION
# Description

<!-- Add a brief description of the context and the approach applied in the pull request -->

This pull request is based on https://github.com/wazuh/wazuh-qa/issues/5609. 

The `Ensure that the manager version is` expected warning has been changed to work with any version. The pipeline to test its performance was successfully executed and it can be seen from the following evidence that the problem was fixed correctly:
- Build: https://ci.wazuh.info/job/Test_e2e_system/337/
- Evidence: [Test_e2e_system_337_test_vulnerability_detector.zip](https://ci.wazuh.info/job/Test_e2e_system/337/artifact/337/Test_e2e_system_337_test_vulnerability_detector.zip)

## Note

This is a backport of https://github.com/wazuh/wazuh-qa/pull/5511 fix in 4.10.0

# Summary
## Before
Before the code was fixed, the results obtained in https://github.com/wazuh/wazuh/issues/24809#issuecomment-2247927918 were:
![image](https://github.com/user-attachments/assets/ab6d96be-0a9d-4bf1-868e-e9783f087cf4)
![image](https://github.com/user-attachments/assets/89f1f2d3-77bd-4f7e-ab3d-3c6eec6503b9)

## After
Now, after the code was fixed:
![image](https://github.com/user-attachments/assets/4986d19f-6d6c-422e-b532-9c2e2e4e5a70)
![image](https://github.com/user-attachments/assets/3fe0c13b-b41b-4d90-8c29-7029c479fb08)

---

## Testing performed

<!-- At most there can only be this table. It must be updated if a new test has been performed. It is important to update the commit that has been tested! -->
<!-- Notes: 
    - If you use a package, add its version, otherwise remove the section.
    - If you add documentation or something that does not require running a test, remove the section.
-->

|OS|Package used|
|--|--|
|||

| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | :green_circle: :green_circle:  | ⚫⚫ |         |    https://github.com/wazuh/wazuh-qa/commit/68ed5f35e89fcf39e6852b488ee13f80921dff1c     | Nothing to highlight |