### PR TITLE
Unnecessary reference to debian file in dashboard task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed dashboard deploy in wazuh-qa-environment pipeline ([#5637](https://github.com/wazuh/wazuh-qa/pull/5637)) \- (Tests)
 - Changed 'Ensure that the manager version is' expected warning to an agnostic version of regex ([#5630](https://github.com/wazuh/wazuh-qa/pull/5630)) \- (Tests)
 - Adding fixed and dynamic waits to port status checks ([#5627](https://github.com/wazuh/wazuh-qa/pull/5627)) (Framework)
 - Fixed custom storage for AMIs ([#5625](https://github.com/wazuh/wazuh-qa/pull/5625)) \- (Framework)

--- a/provisioning/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
+++ b/provisioning/roles/wazuh/wazuh-dashboard/tasks/Debian.yml
@@ -1,7 +1,6 @@
 ---
 - block:
 
-  - include_vars: debian.yml
   - name: Add apt repository signing key
     apt_key:
       url: "{{ wazuh_repo.gpg }}"


### PR DESCRIPTION
### Closing/Related Issue

Closes [issue](https://github.com/wazuh/wazuh-jenkins/issues/6825)

### Description

Unnecessary reference to debian file in dashboard task detected in qa-environment related to debian file deletion. Explained [here](https://github.com/wazuh/wazuh-jenkins/issues/6825#issuecomment-2270910145).

## Tasks
- [x] Fix the error in the dashboard. Build:

  - https://ci.wazuh.info/job/Wazuh_QA_environment/1201/