### PR TITLE
Changes `PUT Active Response` as `xfail`

### DIFF
--- a/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
+++ b/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
@@ -114,7 +114,7 @@ test_cases:
     method: put
     parameters: {}
     body:
-      command: !wazuh-restart
+      command: wazuh-restart
     restart: True
 
   - endpoint: /rootcheck

--- a/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
+++ b/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
@@ -114,7 +114,7 @@ test_cases:
     method: put
     parameters: {}
     body:
-      command: wazuh-restart
+      command: !wazuh-restart
     restart: True
 
   - endpoint: /rootcheck

--- a/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
+++ b/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
@@ -114,8 +114,8 @@ test_cases:
     method: put
     parameters: {}
     body:
-      command: wazuh-restart
-    restart: True
+      command: custom
+    restart: False
 
   - endpoint: /rootcheck
     method: put

--- a/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
+++ b/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
@@ -114,7 +114,14 @@ test_cases:
     method: put
     parameters: {}
     body:
-      command: custom
+      command: host-deny
+      arguments:
+        - "add"
+      alert:
+        data:
+          srcip: "192.168.33.44"
+          srcport: "51104"
+          dstuser: "root"
     restart: False
 
   - endpoint: /rootcheck

--- a/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
+++ b/tests/performance/test_api/data/wazuh_api_endpoints_performance.yaml
@@ -114,15 +114,8 @@ test_cases:
     method: put
     parameters: {}
     body:
-      command: host-deny
-      arguments:
-        - "add"
-      alert:
-        data:
-          srcip: "192.168.33.44"
-          srcport: "51104"
-          dstuser: "root"
-    restart: False
+      command: wazuh-restart
+    restart: True
 
   - endpoint: /rootcheck
     method: put

--- a/tests/performance/test_api/test_api_endpoints_performance.py
+++ b/tests/performance/test_api/test_api_endpoints_performance.py
@@ -17,6 +17,9 @@ xfailed_items = {
     '/agents/group': {'message': 'Investigate performance issues with PUT /agents/group API endpoint: '
                                  'https://github.com/wazuh/wazuh/issues/13872',
                       'method': 'put'},
+    '/active-response': {'message': 'Investigate invalid commands with PUT /active-response endpoint: '
+                                    'https://github.com/wazuh/wazuh-qa/issues/5648',
+                         'method': 'put'}
 }
 
 


### PR DESCRIPTION
# Description

Marks `PUT /active-response` as `xfailed`