### PR TITLE
Added support for macOS 14.6 to the Allocation module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [4.9.1] - TBD
 
+### Added
+
+- Added support for macOS 14.6 to the Allocation module (Vagrant) ([#5671](https://github.com/wazuh/wazuh-qa/pull/5671)) \- (Framework)
+
 ## [4.9.0] - TBD
 
 ### Added

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -170,12 +170,16 @@ vagrant:
     box: development/macos-sonoma
     box_version: 0.0.0
     virtualizer: parallels
-  macos-sonoma-14.5-amd64:
-    box: development/macos-sonoma-1450
-    box_version: 0.0.0
-    virtualizer: parallels
   macos-sonoma-14-arm64:
     box: macos-14
+    box_version: 0.0.0
+    virtualizer: parallels
+  macos-sonoma-14.6-arm64:
+    box: macos-1460
+    box_version: 0.0.0
+    virtualizer: parallels
+  macos-sonoma-14.6-amd64:
+    box: development/macos-sonoma-1460
     box_version: 0.0.0
     virtualizer: parallels
   macos-ventura-sign-arm64:

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -426,11 +426,11 @@ aws:
     zone: us-east-1
     user: ec2-user
   macos-sonoma-14-amd64:
-    ami: ami-0cdb66d9dacb7e395
+    ami: ami-0c82be92b15ae585f
     zone: us-east-1
     user: ec2-user
   macos-sonoma-14-arm64:
-    ami: ami-0c45f2bf394dee00c
+    ami: ami-083104674423416b8
     zone: us-east-1
     user: ec2-user
   macos-monterey-12-arm64:

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -418,27 +418,27 @@ aws:
     user: ec2-user
   # Macos
   macos-ventura-13-amd64:
-    ami: ami-0e94a57427e4e0611
+    ami: ami-0c5acb9ce557a3477
     zone: us-east-1
     user: ec2-user
   macos-ventura-13-arm64:
-    ami: ami-0b288e8fb0e803b12
+    ami: ami-01aa3973cdaf40134 
     zone: us-east-1
     user: ec2-user
   macos-sonoma-14-amd64:
-    ami: ami-0873bd33f11079049
+    ami: ami-0cdb66d9dacb7e395
     zone: us-east-1
     user: ec2-user
   macos-sonoma-14-arm64:
-    ami: ami-0dd07a50e5e3d3ccb
+    ami: ami-0c45f2bf394dee00c
     zone: us-east-1
     user: ec2-user
   macos-monterey-12-arm64:
-    ami: ami-0225fc57a58689798
+    ami: ami-03539bbaad2b27b75
     zone: us-east-1
     user: ec2-user
   macos-monterey-12-amd64:
-    ami: ami-0a410356d12928dbc
+    ami: ami-069e306e29db9ed55
     zone: us-east-1
     user: ec2-user
   # Windows


### PR DESCRIPTION
# Description

Closes: https://github.com/wazuh/wazuh/issues/25068

The aim of this PR is to add support for macOS 14.6 to the Allocation module.
- macStadium ARM update: https://github.com/wazuh/wazuh/issues/25068#issuecomment-2277714114
- macStadium Intel update: https://github.com/wazuh/wazuh/issues/25068#issuecomment-2284096466

Also, the Sonoma, Ventura, and Monterey AWS AMIs were updated to the latest versions, in order to provision the latest machines provided by AWS.