### PR TITLE
Support for PowerPC builder Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Support for PowerPC builder Docker image ([#5673](https://github.com/wazuh/wazuh-qa/pull/5673)) \- (Framework)
 - Add RockyLinux 8.10 to Allocator module ([#5524](https://github.com/wazuh/wazuh-qa/pull/5524)) \- (Framework)
 - Add Deployability testing tier 1 ([#5190](https://github.com/wazuh/wazuh-qa/pull/5190)) \- (Framework + Documentation + Tests)
 - Add Workflow module to Wazuh-qa repository ([#4990](https://github.com/wazuh/wazuh-qa/pull/4990)) \- (Tests)

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -25,6 +25,10 @@ vagrant:
     box: testing-debian-image
     box_version: latest
     virtualizer: docker
+  linux-debian-builder-ppc64:
+    box: build-debian-image
+    box_version: latest
+    virtualizer: docker
   linux-debian-10-amd64:
     box: generic/debian10
     box_version: 4.3.8
@@ -66,6 +70,10 @@ vagrant:
     virtualizer: virtualbox
   linux-centos-7-ppc64:
     box: testing-centos-image
+    box_version: latest
+    virtualizer: docker
+  linux-centos-builder-ppc64:
+    box: build-centos-image
     box_version: latest
     virtualizer: docker
   linux-centos-8-amd64:

--- a/deployability/modules/allocation/vagrant/instance.py
+++ b/deployability/modules/allocation/vagrant/instance.py
@@ -57,7 +57,10 @@ class VagrantInstance(Instance):
             None
         """
         if self.arch == 'ppc64':
-            cmd = f"sudo docker run -itd --name={self.identifier} -p {self.ssh_port}:22 {self.docker_image}"
+            if self.docker_image.__contains__("build"):
+                cmd = f"sudo docker run -itd --name={self.identifier} --privileged -v /var/run/docker.sock:/var/run/docker.sock -p {self.ssh_port}:22 {self.docker_image}"
+            else:
+                cmd = f"sudo docker run -itd --name={self.identifier} -p {self.ssh_port}:22 {self.docker_image}"
             output = VagrantUtils.remote_command(cmd, self.remote_host_parameters)
             container_id = output.split("\n")[0]
             public_key = subprocess.run(["cat", str(self.credentials.key_path) + ".pub"],


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-automation/issues/1780

PowerPC Docker images for Debian and Centos are created and the deployment of the Allocator module is modified for these images.


Debian deploy:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size large --instance-name cbordon-test --composite-name linux-debian-builder-ppc64 --working-dir /home/cbordon/Documents/allocator-test/
[2024-08-09 11:07:10] [INFO] ALLOCATOR: Creating instance at /home/cbordon/Documents/allocator-test
[2024-08-09 11:07:15] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-08-09 11:07:15] [DEBUG] ALLOCATOR: Generating new key pair
[2024-08-09 11:07:23] [INFO] ALLOCATOR: Instance cbordon-test-9992 created.
[2024-08-09 11:07:32] [INFO] ALLOCATOR: Instance cbordon-test-9992 started.
[2024-08-09 11:07:32] [INFO] ALLOCATOR: The inventory file generated at /home/cbordon/Documents/allocator-test/cbordon-test-9992/inventory.yaml
[2024-08-09 11:07:32] [INFO] ALLOCATOR: The track file generated at /home/cbordon/Documents/allocator-test/cbordon-test-9992/track.yaml
[2024-08-09 11:07:34] [INFO] ALLOCATOR: SSH connection successful.
[2024-08-09 11:07:34] [INFO] ALLOCATOR: Instance cbordon-test-9992 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /home/cbordon/Documents/allocator-test/cbordon-test-9992/inventory.yaml
ansible_connection: ssh
ansible_host: 140.211.169.152
ansible_port: 2222
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /home/cbordon/Documents/allocator-test/cbordon-test-9992/instance_key
ansible_user: root
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/Documents/allocator-test/cbordon-test-9992/instance_key -o StrictHostKeyChecking=no -p 2222 root@140.211.169.152
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
IT IS POSSIBLE THAT SOMEONE IS DOING SOMETHING NASTY!
Someone could be eavesdropping on you right now (man-in-the-middle attack)!
It is also possible that a host key has just been changed.
The fingerprint for the ED25519 key sent by the remote host is
SHA256:dm0IsoZPdBpwRSTASM+1QZnaPEtNFTehvzRaEJMaItI.
Please contact your system administrator.
Add correct host key in /home/cbordon/.ssh/known_hosts to get rid of this message.
Offending ED25519 key in /home/cbordon/.ssh/known_hosts:942
  remove with:
  ssh-keygen -f "/home/cbordon/.ssh/known_hosts" -R "[140.211.169.152]:2222"
Password authentication is disabled to avoid man-in-the-middle attacks.
Keyboard-interactive authentication is disabled to avoid man-in-the-middle attacks.
UpdateHostkeys is disabled because the host key is not trusted.
Linux 35d1bedb8593 4.9.0-13-powerpc64le wazuh/wazuh-qa#1 SMP Debian 4.9.228-1 (2020-07-05) ppc64le

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
root@35d1bedb8593:~# docker ps
CONTAINER ID   IMAGE                COMMAND               CREATED          STATUS          PORTS                                   NAMES
35d1bedb8593   build-debian-image   "/usr/sbin/sshd -D"   36 seconds ago   Up 33 seconds   0.0.0.0:2222->22/tcp, :::2222->22/tcp   cbordon-test-9992
c4ba55fb9b81   build-debian-image   "/usr/sbin/sshd -D"   20 hours ago     Up 25 minutes   0.0.0.0:8080->22/tcp, :::8080->22/tcp   cbordon-test-3381
root@35d1bedb8593:~# exit
logout
Connection to 140.211.169.152 closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /home/cbordon/Documents/allocator-test/cbordon-test-9992/track.yaml
[2024-08-09 11:08:22] [INFO] ALLOCATOR: Deleting instance from trackfile /home/cbordon/Documents/allocator-test/cbordon-test-9992/track.yaml
[2024-08-09 11:08:24] [DEBUG] ALLOCATOR: Destroying instance cbordon-test-9992
[2024-08-09 11:08:28] [INFO] ALLOCATOR: Instance cbordon-test-9992 deleted.
```

Centos deploy:

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size large --instance-name cbordon-test --composite-name linux-centos-builder-ppc64 --working-dir /home/cbordon/Documents/allocator-test/
[2024-08-09 11:04:03] [INFO] ALLOCATOR: Creating instance at /home/cbordon/Documents/allocator-test
[2024-08-09 11:04:08] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-08-09 11:04:08] [DEBUG] ALLOCATOR: Generating new key pair
[2024-08-09 11:04:17] [INFO] ALLOCATOR: Instance cbordon-test-6807 created.
[2024-08-09 11:04:29] [INFO] ALLOCATOR: Instance cbordon-test-6807 started.
[2024-08-09 11:04:29] [INFO] ALLOCATOR: The inventory file generated at /home/cbordon/Documents/allocator-test/cbordon-test-6807/inventory.yaml
[2024-08-09 11:04:29] [INFO] ALLOCATOR: The track file generated at /home/cbordon/Documents/allocator-test/cbordon-test-6807/track.yaml
[2024-08-09 11:04:31] [INFO] ALLOCATOR: SSH connection successful.
[2024-08-09 11:04:31] [INFO] ALLOCATOR: Instance cbordon-test-6807 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /home/cbordon/Documents/allocator-test/cbordon-test-6807/inventory.yaml
ansible_connection: ssh
ansible_host: 140.211.169.156
ansible_port: 2222
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /home/cbordon/Documents/allocator-test/cbordon-test-6807/instance_key
ansible_user: root
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /home/cbordon/Documents/allocator-test/cbordon-test-6807/instance_key -o StrictHostKeyChecking=no -p 2222 root@140.211.169.156
[root@d0d2224b71a5 ~]# docker ps
CONTAINER ID   IMAGE                COMMAND               CREATED          STATUS          PORTS                  NAMES
d0d2224b71a5   build-centos-image   "/usr/sbin/sshd -D"   57 seconds ago   Up 49 seconds   0.0.0.0:2222->22/tcp   cbordon-test-6807
6aa185c865b5   build-centos-image   "/usr/sbin/sshd -D"   16 minutes ago   Up 16 minutes   0.0.0.0:8080->22/tcp   cbordon-test-2493
[root@d0d2224b71a5 ~]# exit
logout
Connection to 140.211.169.156 closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /home/cbordon/Documents/allocator-test/cbordon-test-6807/track.yaml
[2024-08-09 11:05:46] [INFO] ALLOCATOR: Deleting instance from trackfile /home/cbordon/Documents/allocator-test/cbordon-test-6807/track.yaml
[2024-08-09 11:05:47] [DEBUG] ALLOCATOR: Destroying instance cbordon-test-6807
[2024-08-09 11:05:53] [INFO] ALLOCATOR: Instance cbordon-test-6807 deleted.
```