### PR TITLE
Increase results windows in E2E Vulnerability detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Added support for macOS 14.6 to the Allocation module (Vagrant) ([#5671](https://github.com/wazuh/wazuh-qa/pull/5671)) \- (Framework)
 
+### Fixed
+
+- Increase results windows in E2E Vulnerability detection ([#5712](https://github.com/wazuh/wazuh-qa/pull/5712/)) \- (Framework + Tests)
+
 ## [4.9.0] - TBD
 
 ### Added

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/check_validators.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/check_validators.py
@@ -28,7 +28,7 @@ def compare_expected_found_vulnerabilities(vulnerabilities, expected_vulnerabili
         for vulnerability in expected_vulns:
             if vulnerability not in vulnerabilities.get(agent, []):
                 logging.critical(f"Vulnerability not found for {agent}: {vulnerability}")
-                if agent not in vulnerabilities_not_found:
+                if agent not in vulnerabilities_not_found.keys():
                     vulnerabilities_not_found[agent] = []
                     failed_agents.append(agent)
 
@@ -39,9 +39,10 @@ def compare_expected_found_vulnerabilities(vulnerabilities, expected_vulnerabili
         for vulnerability in agent_vulnerabilities:
             if vulnerability not in expected_vulnerabilities.get(agent, []):
                 logging.critical(f"Vulnerability unexpected found for {agent}: {vulnerability}")
-                if agent not in vulnerabilities_unexpected:
+                if agent not in vulnerabilities_unexpected.keys():
                     vulnerabilities_unexpected[agent] = []
-                    failed_agents.append(agent)
+                    if agent not in failed_agents:
+                        failed_agents.append(agent)
 
                 result = False
                 vulnerabilities_unexpected[agent].append(vulnerability)
@@ -161,4 +162,3 @@ no_errors = lambda x: all(
     not any(x[host][level] for level in ["ERROR", "CRITICAL", "WARNING"])
     for host in x
 )
-

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -31,6 +31,7 @@ from wazuh_testing.tools.system import HostManager
 
 
 WAZUH_STATES_VULNERABILITIES_INDEXNAME_TEMPLATE = 'wazuh-states-vulnerabilities-{cluster_name}'
+INDEXER_RESULT_WINDOWS_VULN_E2E = 50000
 
 
 def get_wazuh_states_vulnerabilities_indexname(cluster_name: str = 'wazuh') -> str:

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/indexer_api.py
@@ -177,3 +177,36 @@ def delete_index(host_manager: HostManager, credentials: dict = {'user': 'admin'
 
     requests.delete(url=url, verify=False,
                     auth=requests.auth.HTTPBasicAuth(credentials['user'], credentials['password']), headers=headers)
+
+
+def extend_result_window(host_manager: HostManager, credentials: dict = {'user': 'admin', 'password': 'changeme'},
+                         index: str = 'wazuh-alerts*', new_max_result_window: int = 100000):
+    """Extend the max_result_window setting for a Wazuh Indexer index.
+
+    Args:
+        host_manager: An instance of the HostManager class containing information about hosts.
+        credentials (Optional): A dictionary containing the Indexer credentials. Defaults to
+                                 {'user': 'admin', 'password': 'changeme'}.
+        index (Optional): The Indexer index name. Defaults to 'wazuh-alerts*'.
+        new_max_result_window (Optional): The new maximum result window size. Defaults to 100,000.
+    """
+    logging.info(f"Extending max_result_window for {index} index to {new_max_result_window}")
+
+    url = f"https://{host_manager.get_master_ip()}:9200/{index}/_settings"
+    headers = {
+        'Content-Type': 'application/json',
+    }
+    data = {
+        "index": {
+            "max_result_window": new_max_result_window
+        }
+    }
+
+    response = requests.put(url=url, json=data, verify=False,
+                            auth=requests.auth.HTTPBasicAuth(credentials['user'], credentials['password']),
+                            headers=headers)
+
+    if response.status_code == 200:
+        logging.info(f"Successfully updated max_result_window for {index} index.")
+    else:
+        logging.error(f"Failed to update max_result_window for {index} index. Response: {response.text}")

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/remote_operations_handler.py
@@ -243,9 +243,9 @@ def get_vulnerability_alerts(host_manager: HostManager, agent_list, packages_dat
 
 
 def get_vulnerabilities_index(host_manager: HostManager, agent_list, packages_data: List[Dict],
-                              greater_than_timestamp: str = "") -> Dict:
+                              greater_than_timestamp: str = "", size=10000) -> Dict:
     vulnerabilities = get_vulnerabilities_from_states_by_agent(host_manager, agent_list,
-                                                               greater_than_timestamp=greater_than_timestamp)
+                                                               greater_than_timestamp=greater_than_timestamp, size=size)
     package_vulnerabilities = filter_vulnerabilities_by_packages(host_manager, vulnerabilities, packages_data)
 
     return package_vulnerabilities

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
@@ -275,7 +275,8 @@ def parse_vulnerabilities_from_states(vulnerabilities_states: List) -> List:
 
 
 def get_vulnerabilities_from_states_by_agent(host_manager: HostManager, agents: List[str],
-                                             greater_than_timestamp: str = None, cluster_name='wazuh') -> dict:
+                                             greater_than_timestamp: str = None, cluster_name='wazuh',
+                                             size=10000) -> dict:
     """Get vulnerabilities from the vulnerability state index by agent.
 
     Args:
@@ -309,8 +310,8 @@ def get_vulnerabilities_from_states_by_agent(host_manager: HostManager, agents: 
                                                            filter=states_filter,
                                                            index=index,
                                                            credentials={'user': indexer_user,
-                                                                        'password': indexer_password}
-                                                           )['hits']['hits']
+                                                                        'password': indexer_password},
+                                                           size=size)['hits']['hits']
         except KeyError as e:
             logging.error(f"No vulnerabilities were obtained for {agent}. Exception {str(e)}")
 

--- a/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
+++ b/deps/wazuh_testing/wazuh_testing/end_to_end/vulnerability_detector.py
@@ -283,6 +283,8 @@ def get_vulnerabilities_from_states_by_agent(host_manager: HostManager, agents: 
         host_manager (HostManager): Host manager object.
         agents (list): List of agents.
         greater_than_timestamp (str, optional): Greater than timestamp. Defaults to None.
+        size (int, optional): Maximun number of vulnerabilities to collect.
+            More information in https://opensearch.org/docs/latest/search-plugins/searching-data/paginate
 
     Returns:
         dict: Dictionary of vulnerabilities by agent.

--- a/tests/end_to_end/test_vulnerability_detector/conftest.py
+++ b/tests/end_to_end/test_vulnerability_detector/conftest.py
@@ -52,7 +52,7 @@ from wazuh_testing.end_to_end.configuration import (backup_configurations,
                                                     restore_configuration,
                                                     save_indexer_credentials_into_keystore)
 from wazuh_testing.end_to_end.indexer_api import (
-    get_wazuh_states_vulnerabilities_indexname, delete_index)
+    get_wazuh_states_vulnerabilities_indexname, delete_index, extend_result_window, INDEXER_RESULT_WINDOWS_VULN_E2E)
 from wazuh_testing.end_to_end.logs import (get_hosts_alerts, get_hosts_logs,
                                            truncate_remote_host_group_files)
 from wazuh_testing.end_to_end.remote_operations_handler import (
@@ -320,8 +320,11 @@ def setup(preconditions, teardown, host_manager) -> Generator[Dict, None, None]:
         timeout_vulnerabilities_detected = len(agents_to_check) * PACKAGE_VULNERABILITY_SCAN_TIME
 
         time.sleep(timeout_syscollector_scan + timeout_vulnerabilities_detected)
+        vuln_index = get_wazuh_states_vulnerabilities_indexname()
+        extend_result_window(host_manager, index=vuln_index, new_max_result_window=INDEXER_RESULT_WINDOWS_VULN_E2E)
 
-        vulnerabilities = get_vulnerabilities_index(host_manager, agents_to_check, package_data)
+        vulnerabilities = get_vulnerabilities_index(host_manager, agents_to_check, package_data,
+                                                    size=INDEXER_RESULT_WINDOWS_VULN_E2E)
         vulnerabilities_from_alerts = get_vulnerability_alerts(host_manager, agents_to_check, package_data,
                                                                test_timestamp)
 

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -70,7 +70,9 @@ from wazuh_testing.end_to_end.vulnerability_detector import (TIMEOUT_PER_AGENT_V
                                                              get_vulnerabilities_from_states_by_agent)
 from wazuh_testing.end_to_end.waiters import wait_until_vd_is_updated
 from wazuh_testing.tools.system import HostManager
-
+from wazuh_testing.end_to_end.indexer_api import (INDEXER_RESULT_WINDOWS_VULN_E2E,
+                                                 extend_result_window,
+                                                 get_wazuh_states_vulnerabilities_indexname)
 
 pytestmark = [pytest.mark.e2e, pytest.mark.vulnerability_detector, pytest.mark.tier0]
 
@@ -192,6 +194,11 @@ def configure_vulnerability_detection_test_environment(
     yield test_timestamp
 
 
+def max_result_window(host_manager):
+    vuln_index = get_wazuh_states_vulnerabilities_indexname()
+    extend_result_window(host_manager, index=vuln_index, new_max_result_window=INDEXER_RESULT_WINDOWS_VULN_E2E)
+
+
 @pytest.mark.filterwarnings("ignore::urllib3.exceptions.InsecureRequestWarning")
 class TestInitialScans:
     # Checks definition
@@ -254,7 +261,7 @@ class TestInitialScans:
         configure_vulnerability_detection_test_environment,
         record_property,
         clean_environment_logs,
-        delete_states_vulnerability_index,
+        delete_states_vulnerability_index
     ):
         """
         description: Validates the initiation of the first Syscollector scans across all agents in the environment.
@@ -326,11 +333,13 @@ class TestInitialScans:
         logging.critical("Waiting until agent all agents have been scanned.")
         time.sleep(TIMEOUT_PER_AGENT_VULNERABILITY_FIRST_SCAN * len(AGENTS_SCANNED_FIRST_SCAN))
 
+        max_result_window(host_manager)
         logging.critical("Checking vulnerabilities in the index")
         vuln_by_agent_index = get_vulnerabilities_from_states_by_agent(
             host_manager,
             AGENTS_SCANNED_FIRST_SCAN,
             greater_than_timestamp=FIRST_SCAN_TIME,
+            size=INDEXER_RESULT_WINDOWS_VULN_E2E
         )
 
         # Store the vulnerabilities in the global variable to make the comparision in test_consistency_initial_scans
@@ -371,7 +380,7 @@ class TestInitialScans:
 
         logging.critical("Checking for errors in the environment")
         unexpected_errors = check_errors_in_environment(
-            host_manager, expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS
+            host_manager, expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS, error_levels=['ERROR', 'CRITICAL']
         )
 
         test_result.validate_check(
@@ -501,10 +510,12 @@ class TestInitialScans:
 
         global FIRST_SCAN_TIME
 
+        max_result_window(host_manager)
+
         logging.critical("Checking vulnerabilities in the index")
         vuln_by_agent_index = get_vulnerabilities_from_states_by_agent(
-            host_manager, agents_to_check_vulns, greater_than_timestamp=FIRST_SCAN_TIME
-        )
+            host_manager, agents_to_check_vulns, greater_than_timestamp=FIRST_SCAN_TIME,
+            size=INDEXER_RESULT_WINDOWS_VULN_E2E)
 
         logging.critical(
             "Checking that all agents has been scanned and generated vulnerabilities in the index"
@@ -522,7 +533,7 @@ class TestInitialScans:
         unexpected_errors = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=get_timestamp,
+            greater_than_timestamp=get_timestamp, error_levels=['ERROR','CRITICAL']
         )
 
         test_result.validate_check(
@@ -707,8 +718,10 @@ class TestScanSyscollectorCases:
         time.sleep(VD_E2E_TIMEOUT_SYSCOLLECTOR_SCAN + PACKAGE_VULNERABILITY_SCAN_TIME * len(AGENTS_SCANNED_FIRST_SCAN))
 
         package_data = [body["package"]]
+        max_result_window(host_manager)
 
-        vulnerabilities = get_vulnerabilities_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, package_data)
+        vulnerabilities = get_vulnerabilities_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, package_data,
+                                                    size=INDEXER_RESULT_WINDOWS_VULN_E2E)
         expected_vulnerabilities = get_expected_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, body["operation"],
                                                       body["package"])
         duplicated_vulnerabilities = get_duplicated_vulnerabilities(vulnerabilities)
@@ -747,7 +760,7 @@ class TestScanSyscollectorCases:
         errors_environment = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=test_timestamp,
+            greater_than_timestamp=test_timestamp, error_levels=['ERROR','CRITICAL']
         )
         test_result.validate_check("no_errors", [Evidence("error_level_messages", errors_environment)])
 
@@ -796,8 +809,10 @@ class TestScanSyscollectorCases:
         time.sleep(VD_E2E_TIMEOUT_SYSCOLLECTOR_SCAN + PACKAGE_VULNERABILITY_SCAN_TIME * len(AGENTS_SCANNED_FIRST_SCAN))
 
         package_data = [body["package"]]
+        max_result_window(host_manager)
 
-        vulnerabilities = get_vulnerabilities_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, package_data)
+        vulnerabilities = get_vulnerabilities_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, package_data,
+                                                    size=INDEXER_RESULT_WINDOWS_VULN_E2E)
         expected_vulnerabilities = get_expected_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, body["operation"],
                                                       body["package"])
 
@@ -872,7 +887,7 @@ class TestScanSyscollectorCases:
         errors_environment = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=test_timestamp,
+            greater_than_timestamp=test_timestamp, error_levels=['ERROR','CRITICAL']
         )
 
         test_result.validate_check("no_errors", [Evidence("error_level_messages", errors_environment)])
@@ -928,8 +943,10 @@ class TestScanSyscollectorCases:
             package_data = [body["package"]["to"], body["package"]["from"]]
         else:
             package_data = [body["package"]]
+        max_result_window(host_manager)
 
-        vulnerabilities = get_vulnerabilities_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, package_data)
+        vulnerabilities = get_vulnerabilities_index(host_manager, AGENTS_SCANNED_FIRST_SCAN, package_data,
+                                                    size=INDEXER_RESULT_WINDOWS_VULN_E2E)
         expected_vulnerabilities = get_expected_index(host_manager, AGENTS_SCANNED_FIRST_SCAN,
                                                       body["operation"], body["package"])
         duplicated_vulnerabilities = get_duplicated_vulnerabilities(vulnerabilities)
@@ -1001,7 +1018,7 @@ class TestScanSyscollectorCases:
         errors_environment = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=test_timestamp,
+            greater_than_timestamp=test_timestamp, error_levels=['ERROR','CRITICAL']
         )
 
         test_result.validate_check("no_errors", [Evidence("error_level_messages", errors_environment)])

--- a/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
+++ b/tests/end_to_end/test_vulnerability_detector/test_vulnerability_detector.py
@@ -380,7 +380,7 @@ class TestInitialScans:
 
         logging.critical("Checking for errors in the environment")
         unexpected_errors = check_errors_in_environment(
-            host_manager, expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS, error_levels=['ERROR', 'CRITICAL']
+            host_manager, expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS
         )
 
         test_result.validate_check(
@@ -533,7 +533,7 @@ class TestInitialScans:
         unexpected_errors = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=get_timestamp, error_levels=['ERROR','CRITICAL']
+            greater_than_timestamp=get_timestamp
         )
 
         test_result.validate_check(
@@ -760,7 +760,7 @@ class TestScanSyscollectorCases:
         errors_environment = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=test_timestamp, error_levels=['ERROR','CRITICAL']
+            greater_than_timestamp=test_timestamp
         )
         test_result.validate_check("no_errors", [Evidence("error_level_messages", errors_environment)])
 
@@ -887,7 +887,7 @@ class TestScanSyscollectorCases:
         errors_environment = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=test_timestamp, error_levels=['ERROR','CRITICAL']
+            greater_than_timestamp=test_timestamp
         )
 
         test_result.validate_check("no_errors", [Evidence("error_level_messages", errors_environment)])
@@ -1018,7 +1018,7 @@ class TestScanSyscollectorCases:
         errors_environment = check_errors_in_environment(
             host_manager,
             expected_errors=VULNERABILITY_DETECTION_E2E_EXPECTED_ERRORS,
-            greater_than_timestamp=test_timestamp, error_levels=['ERROR','CRITICAL']
+            greater_than_timestamp=test_timestamp
         )
 
         test_result.validate_check("no_errors", [Evidence("error_level_messages", errors_environment)])


### PR DESCRIPTION
# Description

IT was detected in https://github.com/wazuh/wazuh-qa/issues/5699, that the E2E Vulnerability detection tests were failing due to the result windows for the Indexer were not enough for some agents in the environment, leading to some vulnerabilities being missing.

More information at https://github.com/wazuh/wazuh-qa/issues/5699#issuecomment-2326993520

# Changes
- Increase result windows to 50000

## Testing performed


**Build**: https://ci.wazuh.info/job/Test_e2e_system/368/


> [!NOTE]
> Tested along with https://github.com/wazuh/wazuh-qa/issues/5699 in a temporal branch