### PR TITLE
Updated Debian 12 AMIs and Box to 12.7 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Updated Debian 12 AMIs and Box to 12.7 version ([#5735](https://github.com/wazuh/wazuh-qa/pull/5735)) \- (Framework)
 - Increase Feed update timeout in waiters.py ([#5668](https://github.com/wazuh/wazuh-qa/pull/5668)) \- (Framework)
 - Set `/active-response` as xfail ([#5660](https://github.com/wazuh/wazuh-qa/pull/5660)) \- (Tests)
 - Modify the directory name for machines deployed in AWS ([#5635](https://github.com/wazuh/wazuh-qa/pull/5635)) \- (Framework)

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -35,7 +35,7 @@ vagrant:
     virtualizer: virtualbox
   linux-debian-12-amd64:
     box: debian/bookworm64
-    box_version: 12.20231211.1
+    box_version: 12.20240905.1
     virtualizer: virtualbox
   # Oracle Linux
   linux-oracle-7-amd64:
@@ -268,11 +268,11 @@ aws:
     zone: us-east-1
     user: admin
   linux-debian-12-amd64:
-    ami: ami-055c8118725fe3a84
+    ami: ami-014124f30c18be425
     zone: us-east-1
     user: admin
   linux-debian-12-arm64:
-    ami: ami-06703877c23c4ddf1
+    ami: ami-027a194fc587a2e82
     zone: us-east-1
     user: admin
   # Oracle Linux
@@ -422,7 +422,7 @@ aws:
     zone: us-east-1
     user: ec2-user
   macos-ventura-13-arm64:
-    ami: ami-01aa3973cdaf40134 
+    ami: ami-01aa3973cdaf40134
     zone: us-east-1
     user: ec2-user
   macos-sonoma-14-amd64:


### PR DESCRIPTION
close https://github.com/wazuh/wazuh/issues/25686

AMIs and Vagrant box for Debian updated to version 12.7

### Vagrant test

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size micro --instance-name debian-test --composite-name linux-debian-12-amd64
[2024-09-11 13:16:35] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-09-11 13:16:36] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-09-11 13:16:36] [DEBUG] ALLOCATOR: Generating new key pair
[2024-09-11 13:16:39] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-09-11 13:16:39] [INFO] ALLOCATOR: Instance debian-test-1473 created.
[2024-09-11 13:17:16] [INFO] ALLOCATOR: Instance debian-test-1473 started.
[2024-09-11 13:17:18] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/debian-test-1473/inventory.yaml
[2024-09-11 13:17:18] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/debian-test-1473/track.yaml
[2024-09-11 13:17:18] [INFO] ALLOCATOR: SSH connection successful.
[2024-09-11 13:17:18] [INFO] ALLOCATOR: Instance debian-test-1473 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/debian-test-1473/inventory.yaml
ansible_connection: ssh
ansible_host: 192.168.57.5
ansible_port: 22
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/debian-test-1473/instance_key
ansible_user: vagrant
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /tmp/wazuh-qa/debian-test-1473/instance_key -o StrictHostKeyChecking=no vagrant@192.168.57.5
Linux bookworm 6.1.0-25-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.106-3 (2024-08-26) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
vagrant@bookworm:~$ cat /etc/debian_version 
12.7
vagrant@bookworm:~$ exit
logout
Connection to 192.168.57.5 closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/debian-test-1473/track.yaml
[2024-09-11 13:18:01] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/debian-test-1473/track.yaml
[2024-09-11 13:18:01] [DEBUG] ALLOCATOR: Destroying instance debian-test-1473
[2024-09-11 13:18:06] [INFO] ALLOCATOR: Instance debian-test-1473 deleted.
```

### AWS AMD64

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider aws --size micro --label-team devops --label-termination-date 1d  --composite-name linux-debian-12-amd64
[2024-09-11 13:18:41] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-09-11 13:18:42] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-09-11 13:18:42] [DEBUG] ALLOCATOR: Generating new key pair
[2024-09-11 13:18:42] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-5590ABBE-2C98-4782-A24F-E662152D77FC
[2024-09-11 13:19:03] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-5590ABBE-2C98-4782-A24F-E662152D77FC directory to /tmp/wazuh-qa/debian-12-amd64-180
[2024-09-11 13:19:03] [INFO] ALLOCATOR [DEBIAN-12-AMD64]: Instance i-05ce4842936c42722 created.
[2024-09-11 13:19:04] [INFO] ALLOCATOR [DEBIAN-12-AMD64]: Instance i-05ce4842936c42722 started.
[2024-09-11 13:19:05] [INFO] ALLOCATOR [DEBIAN-12-AMD64]: The inventory file generated at /tmp/wazuh-qa/debian-12-amd64-180/inventory.yaml
[2024-09-11 13:19:05] [INFO] ALLOCATOR [DEBIAN-12-AMD64]: The track file generated at /tmp/wazuh-qa/debian-12-amd64-180/track.yaml
[2024-09-11 13:19:24] [WARNING] ALLOCATOR [DEBIAN-12-AMD64]: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 3.91.234.153
[2024-09-11 13:19:56] [INFO] ALLOCATOR [DEBIAN-12-AMD64]: SSH connection successful.
[2024-09-11 13:19:56] [INFO] ALLOCATOR [DEBIAN-12-AMD64]: Instance i-05ce4842936c42722 created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/debian-12-amd64-180/inventory.yaml
ansible_connection: ssh
ansible_host: ec2-3-91-234-153.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/debian-12-amd64-180/debian-12-amd64-key-3698
ansible_user: admin
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /tmp/wazuh-qa/debian-12-amd64-180/debian-12-amd64-key-3698 -o StrictHostKeyChecking=no -p 2200 admin@ec2-3-91-234-153.compute-1.amazonaws.com
Warning: Permanently added '[ec2-3-91-234-153.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Linux ip-172-31-17-203 6.1.0-25-cloud-amd64 #1 SMP PREEMPT_DYNAMIC Debian 6.1.106-3 (2024-08-26) x86_64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Wed Sep 11 16:00:43 2024 from 190.224.231.44
admin@ip-172-31-17-203:~$ cat /etc/debian_version 
12.7
admin@ip-172-31-17-203:~$ exit
logout
Connection to ec2-3-91-234-153.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/debian-12-amd64-180/track.yaml 
[2024-09-11 13:20:37] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/debian-12-amd64-180/track.yaml
[2024-09-11 13:20:38] [DEBUG] ALLOCATOR: Deleting credentials: debian-12-amd64-key-3698
[2024-09-11 13:21:26] [INFO] ALLOCATOR [DEBIAN-12-AMD64]: Instance i-05ce4842936c42722 deleted.
```

### AWS ARM64

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider aws --size micro --label-team devops --label-termination-date 1d  --composite-name linux-debian-12-arm64
[2024-09-11 13:21:35] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-09-11 13:21:36] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-09-11 13:21:36] [DEBUG] ALLOCATOR: Generating new key pair
[2024-09-11 13:21:36] [DEBUG] ALLOCATOR: Creating base directory: /tmp/wazuh-qa/AWS-FF5E6B71-B05C-4B03-A79C-A7CD00105AC5
[2024-09-11 13:21:56] [DEBUG] ALLOCATOR: Renaming temp /tmp/wazuh-qa/AWS-FF5E6B71-B05C-4B03-A79C-A7CD00105AC5 directory to /tmp/wazuh-qa/debian-12-arm64-6281
[2024-09-11 13:21:56] [INFO] ALLOCATOR [DEBIAN-12-ARM64]: Instance i-0d57bac0efb5e7aab created.
[2024-09-11 13:21:58] [INFO] ALLOCATOR [DEBIAN-12-ARM64]: Instance i-0d57bac0efb5e7aab started.
[2024-09-11 13:21:58] [INFO] ALLOCATOR [DEBIAN-12-ARM64]: The inventory file generated at /tmp/wazuh-qa/debian-12-arm64-6281/inventory.yaml
[2024-09-11 13:21:58] [INFO] ALLOCATOR [DEBIAN-12-ARM64]: The track file generated at /tmp/wazuh-qa/debian-12-arm64-6281/track.yaml
[2024-09-11 13:22:18] [WARNING] ALLOCATOR [DEBIAN-12-ARM64]: Error on attempt 1 of 30: [Errno None] Unable to connect to port 2200 on 204.236.221.159
[2024-09-11 13:22:49] [INFO] ALLOCATOR [DEBIAN-12-ARM64]: SSH connection successful.
[2024-09-11 13:22:49] [INFO] ALLOCATOR [DEBIAN-12-ARM64]: Instance i-0d57bac0efb5e7aab created successfully.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ cat /tmp/wazuh-qa/debian-12-arm64-6281/inventory.yaml
ansible_connection: ssh
ansible_host: ec2-204-236-221-159.compute-1.amazonaws.com
ansible_port: 2200
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_ssh_private_key_file: /tmp/wazuh-qa/debian-12-arm64-6281/debian-12-arm64-key-7693
ansible_user: admin
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ ssh -i /tmp/wazuh-qa/debian-12-arm64-6281/debian-12-arm64-key-7693 -o StrictHostKeyChecking=no -p 2200 admin@ec2-204-236-221-159.compute-1.amazonaws.com
Warning: Permanently added '[ec2-204-236-221-159.compute-1.amazonaws.com]:2200' (ED25519) to the list of known hosts.
Linux ip-172-31-27-37 6.1.0-25-cloud-arm64 #1 SMP Debian 6.1.106-3 (2024-08-26) aarch64

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Wed Sep 11 16:10:53 2024 from 190.224.231.44
admin@ip-172-31-27-37:~$ cat /etc/debian_version 
12.7
admin@ip-172-31-27-37:~$ exit
logout
Connection to ec2-204-236-221-159.compute-1.amazonaws.com closed.
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/debian-12-arm64-6281/track.yaml 
[2024-09-11 13:23:23] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/debian-12-arm64-6281/track.yaml
[2024-09-11 13:23:24] [DEBUG] ALLOCATOR: Deleting credentials: debian-12-arm64-key-7693
[2024-09-11 13:24:12] [INFO] ALLOCATOR [DEBIAN-12-ARM64]: Instance i-0d57bac0efb5e7aab deleted.
```