### PR TITLE
Modify VD E2E tests to use package feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Change in VD E2E tests to use package feed instead of CTI feed ([#5739](https://github.com/wazuh/wazuh-qa/pull/5739)) \- (Tests)
+- Improve VD plots title ([#5740](https://github.com/wazuh/wazuh-qa/pull/5740)) \- (Framework)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Added support for macOS 14.6 to the Allocation module (Vagrant) ([#5671](https://github.com/wazuh/wazuh-qa/pull/5671)) \- (Framework)
 
+### Changed
+
+- Change in VD E2E tests to use package feed instead of CTI feed ([#5739](https://github.com/wazuh/wazuh-qa/pull/5739)) \- (Tests)
+
 ### Fixed
 
 - Increase results windows in E2E Vulnerability detection ([#5712](https://github.com/wazuh/wazuh-qa/pull/5712/)) \- (Framework + Tests)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Change in VD E2E tests to use package feed instead of CTI feed ([#5739](https://github.com/wazuh/wazuh-qa/pull/5739)) \- (Tests)
-- Improve VD plots title ([#5740](https://github.com/wazuh/wazuh-qa/pull/5740)) \- (Framework)
 
 ### Fixed
 

--- a/provisioning/environments/e2e_vulnerability_detector.yaml
+++ b/provisioning/environments/e2e_vulnerability_detector.yaml
@@ -3,40 +3,7 @@ manager1:
     os: ubuntu_22
     type: master
 
-manager2:
-    roles: [manager, filebeat]
-    os: ubuntu_22
-    type: worker
-
 agent1:
     roles: [agent]
-    os: centos_7
-    manager: manager1
-
-agent2:
-    roles: [agent]
-    os: windows_11
-    manager: manager2
-
-agent3:
-    roles: [agent]
     os: ubuntu_22
     manager: manager1
-
-agent4:
-    roles: [agent]
-    os: centos_7
-    manager: manager1
-    architecture: arm64v8
-
-agent5:
-    roles: [agent]
-    os: ubuntu_22
-    manager: manager2
-    architecture: arm64v8
-
-agent6:
-    roles: [agent]
-    os: macos_1400
-    manager: manager1
-    architecture: arm64v8

--- a/provisioning/environments/e2e_vulnerability_detector.yaml
+++ b/provisioning/environments/e2e_vulnerability_detector.yaml
@@ -3,7 +3,40 @@ manager1:
     os: ubuntu_22
     type: master
 
+manager2:
+    roles: [manager, filebeat]
+    os: ubuntu_22
+    type: worker
+
 agent1:
+    roles: [agent]
+    os: centos_7
+    manager: manager1
+
+agent2:
+    roles: [agent]
+    os: windows_11
+    manager: manager2
+
+agent3:
     roles: [agent]
     os: ubuntu_22
     manager: manager1
+
+agent4:
+    roles: [agent]
+    os: centos_7
+    manager: manager1
+    architecture: arm64v8
+
+agent5:
+    roles: [agent]
+    os: ubuntu_22
+    manager: manager2
+    architecture: arm64v8
+
+agent6:
+    roles: [agent]
+    os: macos_1400
+    manager: manager1
+    architecture: arm64v8

--- a/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
@@ -7,8 +7,6 @@
             value: 'yes'
         - feed-update-interval:
             value: 10h
-        - offline-url:
-            value: 'https://localhost'
     - section: indexer
       elements:
         - enabled:

--- a/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
+++ b/tests/end_to_end/test_vulnerability_detector/configurations/manager.yaml
@@ -7,6 +7,8 @@
             value: 'yes'
         - feed-update-interval:
             value: 10h
+        - offline-url:
+            value: 'https://localhost'
     - section: indexer
       elements:
         - enabled:


### PR DESCRIPTION
### Closing/Related Issue

Closes #5700

### Description

Modify VD E2E tests to use package feed instead of CTI feed.

## Tasks

- [x] Test that the suggested change works as expected.
- [x] If it works, implement this change to E2E.

## Evidences

- Build: https://ci.wazuh.info/job/Test_e2e_system/370/
- Report: [Test_e2e_system_370_test_vulnerability_detector.zip](https://github.com/user-attachments/files/17027615/Test_e2e_system_370_test_vulnerability_detector.2.zip)
>Note: More tests performed in [this commentary](https://github.com/wazuh/wazuh-qa/issues/5700#issuecomment-2345975606).