### PR TITLE
Fix failed to disable wazuh-manager.service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [4.10.0] - TBD
 
+### Fixed
+
+- Fix failed to disable wazuh-manager.service ([#5775])(https://github.com/wazuh/wazuh-qa/pull/5775) \- (Tests)
+
 ## [4.9.1] - TBD
 
 ### Added

--- a/deployability/modules/testing/tests/helpers/manager.py
+++ b/deployability/modules/testing/tests/helpers/manager.py
@@ -89,7 +89,6 @@ class WazuhManager:
             ])
 
         system_commands = [
-                "systemctl disable wazuh-manager",
                 "systemctl daemon-reload"
         ]
 


### PR DESCRIPTION
# Description

After conducting several tests on the issue: https://github.com/wazuh/wazuh-qa/issues/5742, it was concluded that when uninstalling with the `--purge` option, it is not necessary to run `systemctl disable wazuh-manager` afterward. This was causing the error message mentioned in the issue, as after the uninstallation, it would attempt to disable the service, and since it couldn't find it, it displayed that message.

## Testing performed
The job flow was executed again with the applied changes, and the error was not encountered again.

Log:
[jobflow.log](https://github.com/user-attachments/files/17079155/jobflow.log)

Template used: 
[template.txt](https://github.com/user-attachments/files/17134326/template.txt)


Packages used: 4.9.0

| Validation | Jenkins | Local  | OS  | Commit | Notes                |
|--------------------|-----------|---------|--------|-----|--------|
|           | ⚫⚫ | :green_circle:  :green_circle:  |   Ubuntu 24.04      |         | Nothing to highlight |