### PR TITLE
Fix reliability tests regex statements

### DIFF
--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_connection/test_cluster_connection.py
@@ -53,7 +53,7 @@ def test_cluster_connection(artifacts_path):
         with open(log_file) as f:
             s = mmap(f.fileno(), 0, access=ACCESS_READ)
             # Search first successful connection message.
-            conn = re.search(rb'^.*Successfully connected to master.*$', s, flags=re.MULTILINE)
+            conn = re.search(rb'^.*Successful response from master: keepalive*$', s, flags=re.MULTILINE)
             if not conn:
                 pytest.fail(f'Could not find "Successfully connected to master" message in the '
                             f'{node_name.search(log_file)[1]}')

--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py
@@ -15,7 +15,7 @@ configuration = safe_load(open(join(test_data_path, 'configuration.yaml')))['con
 node_name = compile(r'.*/(master|worker_[\d]+)/logs/cluster.log')
 integrity_regex = compile(r'.*Compressing \'files_metadata.json\' of ([0-9]*) files.*|'
                           r'(.*Files to create: ([0-9]*) \| Files to update: '
-                          r'([0-9]*) \| Files to delete: ([0-9]*) \| Files to send: ([0-9]*).*)'.encode())
+                          r'([0-9]*) \| Files to delete: ([0-9]*).*)'.encode())
 repeated_syncs = {}
 
 


### PR DESCRIPTION
# Description

Fix `test_cluster_sync.py` regex statements related to logs.

---

