### PR TITLE
Fix E2E Vulnerability tests to run in different python versions on yum-dependant OS 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [4.10.0] - TBD
 
+### Fixed
+
+- Fix E2E VD tests not working if the Python version is different to 3.9 ([#5787](https://github.com/wazuh/wazuh-qa/pull/5787)) \- (Framework)
+
 ## [4.9.1] - TBD
 
 ### Added

--- a/deps/wazuh_testing/wazuh_testing/tools/system.py
+++ b/deps/wazuh_testing/wazuh_testing/tools/system.py
@@ -513,8 +513,7 @@ class HostManager:
             return result
 
         def install_yum_package(host, url):
-            result = self.get_host(host).ansible("yum", f"name={url} state=present "
-                                                 'disable_gpg_check=True', check=False)
+            result = self.get_host(host).ansible("command", f"yum install -y {url}", check=False)
             return result
 
         def install_pkg_package(host, url):


### PR DESCRIPTION
# Description

This PR fixes the error reported in https://github.com/wazuh/wazuh-qa/issues/5717

---

## Testing performed

It was validated that the root cause of the error lies in the version difference of ansible and ansible-core (dependencies on requirements.txt). The ansible `yum` module doesn't seem to work on version 10.4.0 of ansible and 2.17.4 of ansible-core yet it works fine in versions 8.7.0 and 2.15.12 respectively.
In order to fix this the use of the `yum` module has been replaced by the command used to install the package directly, it has proven to work.

After verifying that it works with Python 3.10 it was tested with Python 3.9, the result is also satisfactory:
```
[qa@ip-x-x-x-x ~]$ yum list installed | grep grafana
grafana.x86_64                          8.5.6-1                       @/grafana-8.5.6-1.x86_64
```