### PR TITLE
Added Jinja 2 as requirenment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added Jinja 2 as requirenment. ([#5814](https://github.com/wazuh/wazuh-qa/pull/5814)) \- (Framework)
 - Add support for macOS 15 (Sequoia) to the DTT tests ([#5777](https://github.com/wazuh/wazuh-qa/pull/5777)) \- (Tests)
 - Added support for macOS 15 (Vagrant) to the Allocation module ([#5743](https://github.com/wazuh/wazuh-qa/pull/5743)) \- (Framework)
 - Add Ubuntu 24.04 support to Deployability testing tier 1 ([#5689])(https://github.com/wazuh/wazuh-qa/pull/5689) \- (Tests)

--- a/deployability/deps/requirements.txt
+++ b/deployability/deps/requirements.txt
@@ -13,3 +13,4 @@ paramiko==3.4.0
 requests==2.31.0
 chardet==5.2.0
 pywinrm==0.4.3
+jinja2


### PR DESCRIPTION
close https://github.com/wazuh/wazuh-automation/issues/1894#top

Jinja2 is added as an allocator requirement

## Test

```console
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python -m venv /tmp/testing-allocator
cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ source /tmp/testing-allocator/bin/activate
(testing-allocator) cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ pip3 install -r deployability/deps/requirements.txt
Collecting ansible_runner==2.3.4
  Using cached ansible_runner-2.3.4-py3-none-any.whl (81 kB)
Requirement already satisfied: boto3==1.29.1 in /tmp/testing-allocator/lib/python3.10/site-packages (from -r deployability/deps/requirements.txt (line 2)) (1.29.1)
Requirement already satisfied: pydantic==2.5.2 in /tmp/testing-allocator/lib/python3.10/site-packages (from -r deployability/deps/requirements.txt (line 3)) (2.5.2)
Collecting ansible
  Downloading ansible-10.5.0-py3-none-any.whl (49.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 49.0/49.0 MB 6.3 MB/s eta 0:00:00
Collecting ruamel.yaml==0.18.5
  Using cached ruamel.yaml-0.18.5-py3-none-any.whl (116 kB)
Collecting ruamel.yaml.clib==0.2.8
  Using cached ruamel.yaml.clib-0.2.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (526 kB)
Collecting graphlib==0.9.5
  Using cached graphlib-0.9.5-py3-none-any.whl
Collecting jsonschema==3.2.0
  Using cached jsonschema-3.2.0-py2.py3-none-any.whl (56 kB)
Requirement already satisfied: PyYAML==6.0.1 in /tmp/testing-allocator/lib/python3.10/site-packages (from -r deployability/deps/requirements.txt (line 9)) (6.0.1)
Requirement already satisfied: colorlog==6.8.0 in /tmp/testing-allocator/lib/python3.10/site-packages (from -r deployability/deps/requirements.txt (line 10)) (6.8.0)
Collecting pytest==7.4.4
  Using cached pytest-7.4.4-py3-none-any.whl (325 kB)
Requirement already satisfied: paramiko==3.4.0 in /tmp/testing-allocator/lib/python3.10/site-packages (from -r deployability/deps/requirements.txt (line 12)) (3.4.0)
Collecting requests==2.31.0
  Using cached requests-2.31.0-py3-none-any.whl (62 kB)
Collecting chardet==5.2.0
  Using cached chardet-5.2.0-py3-none-any.whl (199 kB)
Requirement already satisfied: pywinrm==0.4.3 in /tmp/testing-allocator/lib/python3.10/site-packages (from -r deployability/deps/requirements.txt (line 15)) (0.4.3)
Requirement already satisfied: jinja2 in /tmp/testing-allocator/lib/python3.10/site-packages (from -r deployability/deps/requirements.txt (line 16)) (3.1.4)
Requirement already satisfied: six in /tmp/testing-allocator/lib/python3.10/site-packages (from ansible_runner==2.3.4->-r deployability/deps/requirements.txt (line 1)) (1.16.0)
Collecting pexpect>=4.5
  Downloading pexpect-4.9.0-py2.py3-none-any.whl (63 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 63.8/63.8 KB 4.0 MB/s eta 0:00:00
Collecting packaging
  Downloading packaging-24.1-py3-none-any.whl (53 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 54.0/54.0 KB 8.1 MB/s eta 0:00:00
Collecting python-daemon
  Using cached python_daemon-3.0.1-py3-none-any.whl (31 kB)
Requirement already satisfied: botocore<1.33.0,>=1.32.1 in /tmp/testing-allocator/lib/python3.10/site-packages (from boto3==1.29.1->-r deployability/deps/requirements.txt (line 2)) (1.32.7)
Requirement already satisfied: s3transfer<0.8.0,>=0.7.0 in /tmp/testing-allocator/lib/python3.10/site-packages (from boto3==1.29.1->-r deployability/deps/requirements.txt (line 2)) (0.7.0)
Requirement already satisfied: jmespath<2.0.0,>=0.7.1 in /tmp/testing-allocator/lib/python3.10/site-packages (from boto3==1.29.1->-r deployability/deps/requirements.txt (line 2)) (1.0.1)
Requirement already satisfied: pydantic-core==2.14.5 in /tmp/testing-allocator/lib/python3.10/site-packages (from pydantic==2.5.2->-r deployability/deps/requirements.txt (line 3)) (2.14.5)
Requirement already satisfied: annotated-types>=0.4.0 in /tmp/testing-allocator/lib/python3.10/site-packages (from pydantic==2.5.2->-r deployability/deps/requirements.txt (line 3)) (0.7.0)
Requirement already satisfied: typing-extensions>=4.6.1 in /tmp/testing-allocator/lib/python3.10/site-packages (from pydantic==2.5.2->-r deployability/deps/requirements.txt (line 3)) (4.12.2)
Requirement already satisfied: setuptools in /tmp/testing-allocator/lib/python3.10/site-packages (from jsonschema==3.2.0->-r deployability/deps/requirements.txt (line 8)) (59.6.0)
Collecting pyrsistent>=0.14.0
  Using cached pyrsistent-0.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (117 kB)
Collecting attrs>=17.4.0
  Downloading attrs-24.2.0-py3-none-any.whl (63 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 63.0/63.0 KB 6.9 MB/s eta 0:00:00
Collecting iniconfig
  Using cached iniconfig-2.0.0-py3-none-any.whl (5.9 kB)
Collecting pluggy<2.0,>=0.12
  Using cached pluggy-1.5.0-py3-none-any.whl (20 kB)
Collecting exceptiongroup>=1.0.0rc8
  Downloading exceptiongroup-1.2.2-py3-none-any.whl (16 kB)
Collecting tomli>=1.0.0
  Downloading tomli-2.0.2-py3-none-any.whl (13 kB)
Requirement already satisfied: bcrypt>=3.2 in /tmp/testing-allocator/lib/python3.10/site-packages (from paramiko==3.4.0->-r deployability/deps/requirements.txt (line 12)) (4.2.0)
Requirement already satisfied: cryptography>=3.3 in /tmp/testing-allocator/lib/python3.10/site-packages (from paramiko==3.4.0->-r deployability/deps/requirements.txt (line 12)) (43.0.1)
Requirement already satisfied: pynacl>=1.5 in /tmp/testing-allocator/lib/python3.10/site-packages (from paramiko==3.4.0->-r deployability/deps/requirements.txt (line 12)) (1.5.0)
Requirement already satisfied: idna<4,>=2.5 in /tmp/testing-allocator/lib/python3.10/site-packages (from requests==2.31.0->-r deployability/deps/requirements.txt (line 13)) (3.10)
Requirement already satisfied: charset-normalizer<4,>=2 in /tmp/testing-allocator/lib/python3.10/site-packages (from requests==2.31.0->-r deployability/deps/requirements.txt (line 13)) (3.4.0)
Requirement already satisfied: certifi>=2017.4.17 in /tmp/testing-allocator/lib/python3.10/site-packages (from requests==2.31.0->-r deployability/deps/requirements.txt (line 13)) (2024.8.30)
Requirement already satisfied: urllib3<3,>=1.21.1 in /tmp/testing-allocator/lib/python3.10/site-packages (from requests==2.31.0->-r deployability/deps/requirements.txt (line 13)) (2.0.7)
Requirement already satisfied: xmltodict in /tmp/testing-allocator/lib/python3.10/site-packages (from pywinrm==0.4.3->-r deployability/deps/requirements.txt (line 15)) (0.14.1)
Requirement already satisfied: requests-ntlm>=1.1.0 in /tmp/testing-allocator/lib/python3.10/site-packages (from pywinrm==0.4.3->-r deployability/deps/requirements.txt (line 15)) (1.3.0)
Collecting ansible-core~=2.17.5
  Downloading ansible_core-2.17.5-py3-none-any.whl (2.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.2/2.2 MB 6.8 MB/s eta 0:00:00
Requirement already satisfied: MarkupSafe>=2.0 in /tmp/testing-allocator/lib/python3.10/site-packages (from jinja2->-r deployability/deps/requirements.txt (line 16)) (3.0.1)
Collecting resolvelib<1.1.0,>=0.5.3
  Downloading resolvelib-1.0.1-py2.py3-none-any.whl (17 kB)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /tmp/testing-allocator/lib/python3.10/site-packages (from botocore<1.33.0,>=1.32.1->boto3==1.29.1->-r deployability/deps/requirements.txt (line 2)) (2.9.0.post0)
Requirement already satisfied: cffi>=1.12 in /tmp/testing-allocator/lib/python3.10/site-packages (from cryptography>=3.3->paramiko==3.4.0->-r deployability/deps/requirements.txt (line 12)) (1.17.1)
Collecting ptyprocess>=0.5
  Downloading ptyprocess-0.7.0-py2.py3-none-any.whl (13 kB)
Requirement already satisfied: pyspnego>=0.4.0 in /tmp/testing-allocator/lib/python3.10/site-packages (from requests-ntlm>=1.1.0->pywinrm==0.4.3->-r deployability/deps/requirements.txt (line 15)) (0.11.1)
Collecting docutils
  Downloading docutils-0.21.2-py3-none-any.whl (587 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 587.4/587.4 KB 5.9 MB/s eta 0:00:00
Collecting lockfile>=0.10
  Downloading lockfile-0.12.2-py2.py3-none-any.whl (13 kB)
Collecting setuptools
  Downloading setuptools-75.1.0-py3-none-any.whl (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 6.7 MB/s eta 0:00:00
Requirement already satisfied: pycparser in /tmp/testing-allocator/lib/python3.10/site-packages (from cffi>=1.12->cryptography>=3.3->paramiko==3.4.0->-r deployability/deps/requirements.txt (line 12)) (2.22)
Installing collected packages: resolvelib, ptyprocess, lockfile, graphlib, tomli, setuptools, ruamel.yaml.clib, requests, pyrsistent, pluggy, pexpect, packaging, iniconfig, exceptiongroup, docutils, chardet, attrs, ruamel.yaml, python-daemon, pytest, jsonschema, ansible_runner, ansible-core, ansible
  Attempting uninstall: setuptools
    Found existing installation: setuptools 59.6.0
    Uninstalling setuptools-59.6.0:
      Successfully uninstalled setuptools-59.6.0
  Attempting uninstall: requests
    Found existing installation: requests 2.32.3
    Uninstalling requests-2.32.3:
      Successfully uninstalled requests-2.32.3
Successfully installed ansible-10.5.0 ansible-core-2.17.5 ansible_runner-2.3.4 attrs-24.2.0 chardet-5.2.0 docutils-0.21.2 exceptiongroup-1.2.2 graphlib-0.9.5 iniconfig-2.0.0 jsonschema-3.2.0 lockfile-0.12.2 packaging-24.1 pexpect-4.9.0 pluggy-1.5.0 ptyprocess-0.7.0 pyrsistent-0.20.0 pytest-7.4.4 python-daemon-3.0.1 requests-2.31.0 resolvelib-1.0.1 ruamel.yaml-0.18.5 ruamel.yaml.clib-0.2.8 setuptools-75.1.0 tomli-2.0.2
(testing-allocator) cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$ python3 deployability/modules/allocation/main.py --provider vagrant --size small --instance-name cbordon --composite-name linux-ubuntu-22.04-amd64
/tmp/testing-allocator/lib/python3.10/site-packages/paramiko/pkey.py:100: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "cipher": algorithms.TripleDES,
/tmp/testing-allocator/lib/python3.10/site-packages/paramiko/transport.py:259: CryptographyDeprecationWarning: TripleDES has been moved to cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES and will be removed from this module in 48.0.0.
  "class": algorithms.TripleDES,
[2024-10-15 14:05:51] [DEBUG] SPNEGO._GSS: Python gssapi not available, cannot use any GSSAPIProxy protocols: No module named 'gssapi'
[2024-10-15 14:05:51] [DEBUG] SPNEGO._GSS: Python gssapi IOV extension not available: No module named 'gssapi'
[2024-10-15 14:05:51] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-10-15 14:05:51] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-10-15 14:05:51] [DEBUG] ALLOCATOR: Generating new key pair
[2024-10-15 14:05:55] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-10-15 14:05:55] [INFO] ALLOCATOR: Instance cbordon-3505 created.
[2024-10-15 14:06:37] [INFO] ALLOCATOR: Instance cbordon-3505 started.
[2024-10-15 14:06:39] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/cbordon-3505/inventory.yaml
[2024-10-15 14:06:39] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/cbordon-3505/track.yaml
[2024-10-15 14:06:39] [INFO] ALLOCATOR: SSH connection successful.
[2024-10-15 14:06:39] [INFO] ALLOCATOR: Instance cbordon-3505 created successfully.
(testing-allocator) cbordon@cbordon-MS-7C88:~/Documents/wazuh/repositorios/wazuh-qa$
```