### PR TITLE
Update macOS ventura sign Vagrant box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Update macOS ventura sign Vagrant box ([#5834](https://github.com/wazuh/wazuh-qa/pull/5834)) \- (Framework)
 - Updated Windows server AMis. ([#5831](https://github.com/wazuh/wazuh-qa/pull/5831)) \- (Framework)
 
 ## [4.9.1] - TBD

--- a/deployability/modules/allocation/static/specs/os.yml
+++ b/deployability/modules/allocation/static/specs/os.yml
@@ -191,7 +191,7 @@ vagrant:
     box_version: 0.0.0
     virtualizer: parallels
   macos-ventura-sign-arm64:
-    box: macos-ventura-sign
+    box: macos-ventura-sign2
     box_version: 0.0.0
     virtualizer: parallels
   # Windows


### PR DESCRIPTION
# Description

The macOS Vagrant Box used for package signing has been updated. The previous box had problems restarting once it was provisioned.

## Tests

```console
$ python3 deployability/modules/allocation/main.py --action create --provider vagrant --size medium --composite-name macos-ventura-sign-arm64 --label-issue https://github.com/wazuh/internal-devel-requests/issues/1722

[2024-11-04 10:38:07] [INFO] ALLOCATOR: Creating instance at /tmp/wazuh-qa
[2024-11-04 10:38:13] [INFO] ALLOCATOR: macStadium ARM server has less than 2 VMs running, deploying in this host.
[2024-11-04 10:38:13] [DEBUG] ALLOCATOR: Checking if instance directory exists on remote host
[2024-11-04 10:38:16] [DEBUG] ALLOCATOR: Creating instance directory on remote host
[2024-11-04 10:38:19] [DEBUG] ALLOCATOR: No config provided. Generating from payload
[2024-11-04 10:38:19] [DEBUG] ALLOCATOR: Generating new key pair
[2024-11-04 10:38:22] [DEBUG] ALLOCATOR: Vagrantfile created. Creating instance.
[2024-11-04 10:38:35] [INFO] ALLOCATOR: Instance idr-1722-ventura-sign-2936 created.
[2024-11-04 10:43:52] [INFO] ALLOCATOR: Instance idr-1722-ventura-sign-2936 started.
[2024-11-04 10:44:09] [INFO] ALLOCATOR: The inventory file generated at /tmp/wazuh-qa/idr-1722-ventura-sign-2936/inventory.yaml
[2024-11-04 10:44:09] [INFO] ALLOCATOR: The track file generated at /tmp/wazuh-qa/idr-1722-ventura-sign-2936/track.yaml
[2024-11-04 10:44:11] [INFO] ALLOCATOR: SSH connection successful.
[2024-11-04 10:44:11] [INFO] ALLOCATOR: Instance idr-1722-ventura-sign-2936 created successfully.

$ cat /tmp/wazuh-qa/idr-1722-ventura-sign-2936/inventory.yaml
ansible_connection: ssh
ansible_host: 10.10.0.250
ansible_password: vagrant
ansible_port: 43226
ansible_ssh_common_args: -o StrictHostKeyChecking=no
ansible_user: vagrant

$ ssh -p 43226 -o StrictHostKeyChecking=no vagrant@10.10.0.250
Warning: Permanently added '[10.10.0.250]:43226' (ED25519) to the list of known hosts.
(vagrant@10.10.0.250) Password:

vagrant@venturasign ~ %

$ python3 deployability/modules/allocation/main.py --action delete --track-output /tmp/wazuh-qa/idr-1722-ventura-sign-2936/track.yaml
[2024-11-04 10:48:23] [INFO] ALLOCATOR: Deleting instance from trackfile /tmp/wazuh-qa/idr-1722-ventura-sign-2936/track.yaml
[2024-11-04 10:48:24] [DEBUG] ALLOCATOR: Destroying instance idr-1722-ventura-sign-2936
[2024-11-04 10:48:38] [DEBUG] ALLOCATOR: Deleting remote directory /Users/jenkins/testing/idr-1722-ventura-sign-2936
[2024-11-04 10:48:41] [DEBUG] ALLOCATOR: Killing remote process on port 43226
[2024-11-04 10:48:48] [INFO] ALLOCATOR: Instance idr-1722-ventura-sign-2936 deleted.
```

## Related issue

- https://github.com/wazuh/internal-devel-requests/issues/1722