### PR TITLE
Fix regex value comparison

### DIFF
--- a/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py
+++ b/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync/test_cluster_sync.py
@@ -56,7 +56,7 @@ def test_cluster_sync(artifacts_path):
                                 repeat_counter += 1
                     # If only 1 shared file is synced, it could be the 'client.keys' so it doesn't count as a repeated
                     # log (agents could be registering).
-                    elif sync_logs[i][2:] != (b'0', b'1', b'0', b'0'):
+                    elif sync_logs[i][2:] != (b'0', b'1', b'0'):
                         repeat_counter += 1
 
                     if repeat_counter >= configuration['repeat_threshold']:


### PR DESCRIPTION
# Description

Closes https://github.com/wazuh/wazuh/issues/27052.

Fixes a bug in the `test_cluster_sync.py` file that caused the test to fail.

## Testing performed

<details><summary>Manual test</summary>

It uses the artifacts from the related issue description.

```console
(venv) gasti@gasti:~/work/wazuh-qa/tests/reliability/test_cluster/test_cluster_logs/test_cluster_sync$ python3 -m pytest test_cluster_sync.py --artifacts_path='/home/gasti/Downloads/artifacts'
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.10.14, pytest-7.1.2, pluggy-1.5.0
rootdir: /home/gasti/work/wazuh-qa/tests, configfile: pytest.ini
plugins: metadata-3.1.1, testinfra-5.0.0, html-3.1.1
collected 1 item                                                                                                                                                                                                                             

test_cluster_sync.py .                                                                                                                                                                                                                 [100%]

============================================================================================================= 1 passed in 59.39s =============================================================================================================
```

</details>